### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **HHS Patient Portal**, a full-stack app with three moving parts:
+
+| Service | Port | Start command | Notes |
+| --- | --- | --- | --- |
+| PostgreSQL 16 | 5432 | `sudo pg_ctlcluster 16 main start` | Not auto-started on VM boot; start it before the API. |
+| Flask API (Python) | 3000 | `./run-api.sh` (or `npm run api`) | Reads `.env`; hot-reloads on file save in dev. |
+| Vue 3 + Vite frontend | 5173 | `npm run dev` | Proxies `/api` → `http://localhost:3000` (see `vite.config.ts`). |
+
+Standard commands are documented in `README.md`, `QUICKSTART.md`, `DATABASE_SETUP.md`, and `package.json` scripts. Below are only the non-obvious caveats:
+
+- **`.env` is required and git-ignored.** The API and `seed_users.py` need it. For local dev use `DB_HOST=localhost`, `DB_USER=postgres`, `DB_PASSWORD=postgres`, `DB_NAME=hhs_patient_portal`, and `DB_SSLMODE=disable` (the local PostgreSQL is not built with SSL, so `prefer`/`require` should be avoided). If `.env` is missing, recreate it with those values plus `ALLOWED_ORIGINS=http://localhost:5173` and `DOCUMENTS_STORAGE_BACKEND=local`.
+- **Python runs from a venv at `./venv`** (git-ignored). `npm run api`/`run-api.sh` do `source venv/bin/activate`, and tests use `./venv/bin/python`. The update script recreates/refreshes this venv.
+- **First-time DB bootstrap on a fresh database** (schema is idempotent, safe to re-run):
+  - `sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='hhs_patient_portal'" | grep -q 1 || sudo -u postgres psql -c "CREATE DATABASE hhs_patient_portal;"`
+  - `sudo -u postgres psql -d hhs_patient_portal -f server/db/schema.sql`
+  - `PYTHONPATH=$(pwd) ./venv/bin/python seed_users.py` (creates test users; idempotent).
+  - Note: `./setup-db.sh` also does this but prompts interactively for seed data, so it can block automation.
+- **Test login credentials** (from `seed_users.py`): patient `patient1` / `Patient123!`, doctor `doctor1` / `Doctor123!`.
+- **`server/` is legacy TypeScript and unused** — the live backend is the Python Flask API under `api/`. `.gitignore` intentionally keeps only `server/db/*.sql`.
+- Tests/build: backend `npm run test:backend` (pytest, needs the DB running), frontend `npm run test:frontend` (vitest), build `npm run build` (`vue-tsc && vite build`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the HHS Patient Portal (Vue 3 + Vite frontend, Python Flask API, PostgreSQL) and documents non-obvious startup caveats for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the three services, the git-ignored `.env`/`venv` requirements, first-time DB bootstrap (schema + seed), test credentials, and the legacy `server/` note.
- Registers a minimal, idempotent update script (venv + `pip install` + `npm install`).

No application code was changed.

## Verification

Ran the full stack end-to-end and completed a hello-world flow: logged in as `patient1` and submitted an appointment request (persisted with `PENDING` status).

[patient_portal_login_and_appointment.mp4](https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpatient_portal_login_and_appointment.mp4)

[Patient dashboard after login](https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpatient_dashboard.webp)
[Appointment created with pending status](https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fappointment_confirmed.webp)

**Checks**
- Backend tests: `npm run test:backend` (pytest) — pass
- Frontend tests: `npm run test:frontend` (vitest) — pass
- Build: `npm run build` — pass
- API health: `curl http://localhost:3000/health` — ok
- Login end-to-end via Vite proxy — success

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

