### PR TITLE
Secure provider schedule: redact PHI for other providers' events

### DIFF
--- a/api/routes/events.py
+++ b/api/routes/events.py
@@ -10,6 +10,42 @@ from api.middleware.auth import authenticate
 
 events_bp = Blueprint('events', __name__, url_prefix='/api/events')
 
+_EVENT_TYPE_LABELS = {
+    'appointment': 'Appointment',
+    'reminder': 'Reminder',
+    'note': 'Note',
+    'blocked_time': 'Blocked Time',
+    'meeting': 'Meeting',
+    'other': 'Other',
+}
+
+
+def _generic_event_title(event_type, appointment_status=None):
+    """Return a PHI-safe display title for another provider's event."""
+    if event_type == 'appointment' and appointment_status:
+        return f"Appointment ({appointment_status})"
+    return _EVENT_TYPE_LABELS.get(event_type, 'Other')
+
+
+def _apply_event_visibility(event, viewer_doctor_id):
+    """Tag own events and redact PHI from other providers' schedule rows."""
+    result = dict(event)
+    event_doctor_id = str(result.get('doctor_id', ''))
+    viewer_id = str(viewer_doctor_id)
+    is_own_event = event_doctor_id == viewer_id
+    result['is_own_event'] = is_own_event
+
+    if not is_own_event:
+        result['patient_name'] = None
+        result['patient_id'] = None
+        result['description'] = None
+        result['title'] = _generic_event_title(
+            result.get('event_type'),
+            result.get('appointment_status'),
+        )
+
+    return result
+
 
 def serialize_event(event):
     """Convert event dict with date/time objects to JSON-serializable dict"""
@@ -109,6 +145,8 @@ def get_events():
                        p.first_name || ' ' || p.last_name AS patient_name,
                        d.first_name || ' ' || d.last_name AS provider_name
                 FROM appointments a
+                JOIN doctors d ON d.id = a.doctor_id
+                LEFT JOIN patients p ON p.id = a.patient_id
                 WHERE a.doctor_id = %s
                 AND a.appointment_date::date BETWEEN %s AND %s
             """
@@ -152,9 +190,14 @@ def get_events():
                 'updated_at': apt['updated_at'].isoformat() if isinstance(apt['updated_at'], datetime) else apt.get('updated_at'),
             }
             serialized_events.append(apt_event)
+
+        visible_events = [
+            _apply_event_visibility(event, doctor_id)
+            for event in serialized_events
+        ]
         
         return jsonify({
-            'events': serialized_events
+            'events': visible_events
         }), 200
         
     except Exception:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+
+from api.app import app
+from api.db.connection import execute_query, init_db_pool
+
+
+def _db_available():
+    try:
+        init_db_pool()
+        execute_query('SELECT 1', fetch_one=True)
+        return True
+    except Exception:
+        return False
+
+
+requires_db = pytest.mark.skipif(not _db_available(), reason='PostgreSQL database is not available')
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def login_as(client, username='doctor1', password='Doctor123!'):
+    response = client.post('/api/auth/login', json={
+        'username': username,
+        'password': password,
+    })
+    assert response.status_code == 200, response.get_json()
+    payload = response.get_json()
+    token = payload['sessionToken']
+    return {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json',
+    }

--- a/api/tests/test_events_security.py
+++ b/api/tests/test_events_security.py
@@ -1,0 +1,134 @@
+from api.db.connection import execute_query
+from api.tests.conftest import login_as, requires_db
+
+
+@requires_db
+def test_all_providers_redacts_other_provider_phi(client):
+    headers = login_as(client, 'doctor1')
+
+    response = client.get(
+        '/api/events?start_date=2026-07-10&end_date=2026-07-13&include_all_providers=true',
+        headers=headers,
+    )
+    assert response.status_code == 200, response.get_json()
+    events = response.get_json()['events']
+    assert len(events) > 0
+
+    doctor_ids = {event['doctor_id'] for event in events}
+    assert len(doctor_ids) > 1, 'Expected events from multiple providers in seed data'
+
+    own_events = [event for event in events if event['is_own_event']]
+    other_events = [event for event in events if not event['is_own_event']]
+
+    assert len(own_events) > 0
+    assert len(other_events) > 0
+
+    for event in own_events:
+        assert event['patient_name'] is not None or event['event_type'] in ('meeting', 'blocked_time', 'note', 'other')
+
+    for event in other_events:
+        assert event['patient_name'] is None
+        assert event['patient_id'] is None
+        assert event['description'] is None
+        assert 'Jane' not in (event.get('title') or '')
+        assert 'Smith' not in (event.get('title') or '')
+        assert 'Doe' not in (event.get('title') or '')
+
+
+@requires_db
+def test_default_events_request_returns_only_own_events(client):
+    headers = login_as(client, 'doctor1')
+
+    response = client.get(
+        '/api/events?start_date=2026-07-10&end_date=2026-07-10',
+        headers=headers,
+    )
+    assert response.status_code == 200, response.get_json()
+    events = response.get_json()['events']
+
+    assert len(events) > 0
+    assert all(event['is_own_event'] for event in events)
+
+    doctor_row = execute_query(
+        "SELECT d.id FROM doctors d JOIN users u ON u.id = d.user_id WHERE u.username = %s",
+        ('doctor1',),
+        fetch_one=True,
+    )
+    assert all(str(event['doctor_id']) == str(doctor_row['id']) for event in events)
+
+
+@requires_db
+def test_doctor_cannot_update_another_providers_event(client):
+    headers = login_as(client, 'doctor1')
+
+    other_event = execute_query(
+        """
+        SELECT e.id
+        FROM events e
+        JOIN doctors d ON d.id = e.doctor_id
+        JOIN users u ON u.id = d.user_id
+        WHERE u.username = %s
+        LIMIT 1
+        """,
+        ('doctor2',),
+        fetch_one=True,
+    )
+    assert other_event is not None
+
+    response = client.put(
+        f"/api/events/{other_event['id']}",
+        headers=headers,
+        json={'title': 'Unauthorized update'},
+    )
+    assert response.status_code == 404
+
+
+@requires_db
+def test_doctor_cannot_delete_another_providers_event(client):
+    headers = login_as(client, 'doctor1')
+
+    other_event = execute_query(
+        """
+        SELECT e.id
+        FROM events e
+        JOIN doctors d ON d.id = e.doctor_id
+        JOIN users u ON u.id = d.user_id
+        WHERE u.username = %s
+        LIMIT 1
+        """,
+        ('doctor2',),
+        fetch_one=True,
+    )
+    assert other_event is not None
+
+    response = client.delete(
+        f"/api/events/{other_event['id']}",
+        headers=headers,
+    )
+    assert response.status_code == 404
+
+
+@requires_db
+def test_doctor_cannot_confirm_another_providers_appointment(client):
+    headers = login_as(client, 'doctor1')
+
+    other_appointment = execute_query(
+        """
+        SELECT a.id
+        FROM appointments a
+        JOIN doctors d ON d.id = a.doctor_id
+        JOIN users u ON u.id = d.user_id
+        WHERE u.username = %s
+          AND a.status = 'pending'
+        LIMIT 1
+        """,
+        ('doctor2',),
+        fetch_one=True,
+    )
+    assert other_appointment is not None
+
+    response = client.patch(
+        f"/api/appointments/{other_appointment['id']}/confirm",
+        headers=headers,
+    )
+    assert response.status_code == 404

--- a/src/views/DoctorDashboard.spec.ts
+++ b/src/views/DoctorDashboard.spec.ts
@@ -25,12 +25,12 @@ describe('DoctorDashboard.vue', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Provider Day Schedule')
-    expect(wrapper.text()).toContain('All appointments and events for the selected day across providers')
+    expect(wrapper.text()).toContain('View provider availability across the clinic')
     expect(wrapper.find('.date-input').exists()).toBe(true)
     expect(wrapper.find('.add-event-btn').exists()).toBe(true)
   })
 
-  it('shows events for selected day across providers', async () => {
+  it('shows events for selected day across providers with redacted other-provider details', async () => {
     const today = getLocalDateString(new Date())
     vi.stubGlobal(
       'fetch',
@@ -48,6 +48,7 @@ describe('DoctorDashboard.vue', () => {
               color: '#3b82f6',
               is_all_day: false,
               provider_name: 'Dr. Alice Smith',
+              is_own_event: true,
               created_at: '2026-01-01T00:00:00Z',
               updated_at: '2026-01-01T00:00:00Z'
             },
@@ -55,14 +56,15 @@ describe('DoctorDashboard.vue', () => {
               id: 'apt-123',
               doctor_id: 'doc-2',
               event_type: 'appointment',
-              title: 'Jane Doe (pending)',
+              title: 'Appointment (pending)',
               event_date: today,
               start_time: '09:00:00',
               color: '#f59e0b',
               is_all_day: false,
               provider_name: 'Dr. Bob Jones',
-              patient_name: 'Jane Doe',
+              patient_name: null,
               appointment_status: 'pending',
+              is_own_event: false,
               created_at: '2026-01-01T00:00:00Z',
               updated_at: '2026-01-01T00:00:00Z'
             },
@@ -76,6 +78,7 @@ describe('DoctorDashboard.vue', () => {
               color: '#3b82f6',
               is_all_day: false,
               provider_name: 'Dr. Alice Smith',
+              is_own_event: true,
               created_at: '2026-01-01T00:00:00Z',
               updated_at: '2026-01-01T00:00:00Z'
             }
@@ -94,8 +97,35 @@ describe('DoctorDashboard.vue', () => {
 
     const items = wrapper.findAll('.schedule-item')
     expect(items.length).toBe(2)
-    expect(wrapper.text()).toContain('Confirm')
+    expect(wrapper.text()).toContain('Morning Huddle')
+    expect(wrapper.text()).toContain('Appointment (pending)')
+    expect(wrapper.text()).not.toContain('Jane Doe')
     expect(wrapper.text()).not.toContain('Future Event')
+
+    const otherProviderItem = wrapper.find('.schedule-item--other')
+    expect(otherProviderItem.exists()).toBe(true)
+    expect(otherProviderItem.text()).not.toContain('Confirm')
+    expect(otherProviderItem.text()).not.toContain('Edit')
+    expect(otherProviderItem.text()).not.toContain('Delete')
+
+    const ownProviderItem = wrapper.findAll('.schedule-item').find((item) => !item.classes().includes('schedule-item--other'))
+    expect(ownProviderItem?.text()).toContain('Edit')
+    expect(ownProviderItem?.text()).toContain('Delete')
+  })
+
+  it('requests all providers when loading events', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ events: [] })
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    mount(DoctorDashboard)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalled()
+    const requestUrl = String(fetchMock.mock.calls[0][0])
+    expect(requestUrl).toContain('include_all_providers=true')
   })
 
   it('shows empty state when day has no events', async () => {

--- a/src/views/DoctorDashboard.vue
+++ b/src/views/DoctorDashboard.vue
@@ -3,7 +3,7 @@
     <div class="dashboard-header">
       <div class="header-main">
         <h1>Provider Day Schedule</h1>
-        <p>All appointments and events for the selected day across providers</p>
+        <p>View provider availability across the clinic. Patient details are shown only for your own schedule.</p>
       </div>
       <div class="date-navigation">
         <button @click="previousDay" class="nav-btn">← Previous</button>
@@ -36,21 +36,26 @@
         <div v-for="provider in providerColumns" :key="provider.key" class="provider-column">
           <div class="provider-column-header">{{ provider.label }}</div>
           <div class="provider-events">
-            <div v-for="event in provider.events" :key="event.id" class="schedule-item">
+            <div
+              v-for="event in provider.events"
+              :key="event.id"
+              class="schedule-item"
+              :class="{ 'schedule-item--other': !event.is_own_event }"
+            >
               <div class="event-topline">
                 <span class="event-dot" :style="{ backgroundColor: event.color }"></span>
                 <span class="event-title">{{ event.title }}</span>
               </div>
               <div class="event-meta">
                 <span><strong>Time:</strong> {{ getEventTimeLabel(event) }}</span>
-                <span v-if="event.patient_name"><strong>Patient:</strong> {{ event.patient_name }}</span>
+                <span v-if="event.is_own_event && event.patient_name"><strong>Patient:</strong> {{ event.patient_name }}</span>
                 <span><strong>Type:</strong> {{ formatEventType(event.event_type) }}</span>
                 <span v-if="isAppointmentEvent(event) && getAppointmentStatus(event)">
                   <strong>Status:</strong> {{ getAppointmentStatus(event) }}
                 </span>
               </div>
-              <p v-if="event.description" class="event-description">{{ event.description }}</p>
-              <div class="actions-column">
+              <p v-if="event.is_own_event && event.description" class="event-description">{{ event.description }}</p>
+              <div v-if="event.is_own_event" class="actions-column">
                 <button
                   v-if="isAppointmentEvent(event) && getAppointmentStatus(event) === 'pending'"
                   class="confirm-btn"
@@ -175,6 +180,7 @@ interface DashboardEvent {
   provider_name?: string
   patient_name?: string
   appointment_status?: string
+  is_own_event?: boolean
   created_at: string
   updated_at: string
 }
@@ -616,6 +622,15 @@ onMounted(() => {
   border-radius: 8px;
   background: white;
   padding: 0.75rem;
+}
+
+.schedule-item--other {
+  background: #f9fafb;
+  border-style: dashed;
+}
+
+.schedule-item--other .event-title {
+  color: #4b5563;
 }
 
 .event-topline {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves data security on the provider dashboard schedule while preserving the multi-provider availability view.

- **Backend:** `GET /api/events` now tags each row with `is_own_event` and redacts PHI (patient name/ID, description, specific titles) for other providers' events when `include_all_providers=true`. Other providers' rows show only availability metadata (time, type, generic title, status).
- **Frontend:** `DoctorDashboard.vue` gates patient details and Edit/Delete/Confirm actions to own events, with muted styling for other-provider availability blocks.
- **Bug fix:** Added missing `doctors`/`patients` joins in the own-provider appointments query (caused 500s on default `/api/events` requests).
- **Tests:** Added API integration tests for redaction and mutation isolation, plus updated frontend specs.

## Test plan

- [x] `npm run test:frontend` — DoctorDashboard specs pass
- [x] `npm run test:backend` — events security tests pass (requires PostgreSQL + seed data)
- [ ] Manual: log in as `doctor1` on `/doctor` — see all provider columns; other columns show time blocks without patient names; own column shows full details and edit actions

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-462265cd-daa4-4257-8bcd-36be170aab81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-462265cd-daa4-4257-8bcd-36be170aab81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

