### PR TITLE
Patient notes autosave with provider audit attribution

### DIFF
--- a/api/routes/patient_properties.py
+++ b/api/routes/patient_properties.py
@@ -7,12 +7,25 @@ from flask import Blueprint, request, jsonify, current_app
 from datetime import datetime, date
 from api.db.connection import execute_query
 from api.middleware.auth import authenticate
+from api.utils.audit_log import log_data_access
 
 patient_properties_bp = Blueprint('patient_properties', __name__, url_prefix='/api/patient-properties')
 INSUFFICIENT_PERMISSIONS_ERROR = 'Insufficient permissions'
 FAILED_RETRIEVE_PROPERTIES_ERROR = 'Failed to retrieve patient properties'
 FAILED_CREATE_PROPERTY_ERROR = 'Failed to create patient property'
+FAILED_UPDATE_PROPERTY_ERROR = 'Failed to update patient property'
 FAILED_DELETE_PROPERTY_ERROR = 'Failed to delete patient property'
+
+PROPERTY_SELECT = """
+    SELECT pp.patient_id, pp.property_id, pp.name, pp.description,
+           pp.created_by_doctor_id, pp.updated_by_doctor_id,
+           pp.created_at, pp.updated_at,
+           cb.first_name || ' ' || cb.last_name AS created_by_name,
+           ub.first_name || ' ' || ub.last_name AS updated_by_name
+    FROM patient_properties pp
+    LEFT JOIN doctors cb ON cb.id = pp.created_by_doctor_id
+    LEFT JOIN doctors ub ON ub.id = pp.updated_by_doctor_id
+"""
 
 
 def serialize_property(prop):
@@ -25,6 +38,33 @@ def serialize_property(prop):
     return result
 
 
+def _get_doctor_id(user_id):
+    doctor_row = execute_query(
+        'SELECT id FROM doctors WHERE user_id = %s',
+        (user_id,),
+        fetch_one=True,
+    )
+    return doctor_row['id'] if doctor_row else None
+
+
+def _require_doctor():
+    user = request.user
+    if user.get('role') != 'doctor':
+        return None, (jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403)
+    doctor_id = _get_doctor_id(user['id'])
+    if not doctor_id:
+        return None, (jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403)
+    return doctor_id, None
+
+
+def _fetch_property(patient_id, property_id):
+    query = f"""
+        {PROPERTY_SELECT}
+        WHERE pp.patient_id = %s AND pp.property_id = %s
+    """
+    return execute_query(query, (patient_id, property_id), fetch_one=True)
+
+
 @patient_properties_bp.route('/<patient_id>', methods=['GET'])
 @authenticate
 def list_properties(patient_id):
@@ -33,13 +73,13 @@ def list_properties(patient_id):
         if user.get('role') != 'doctor':
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
 
-        query = """
-            SELECT patient_id, property_id, name, description, created_at, updated_at
-            FROM patient_properties
-            WHERE patient_id = %s
-            ORDER BY property_id
+        query = f"""
+            {PROPERTY_SELECT}
+            WHERE pp.patient_id = %s
+            ORDER BY pp.property_id
         """
         props = execute_query(query, (patient_id,), fetch_all=True) or []
+        log_data_access(user['id'], 'patient_properties', patient_id, 'VIEW', request)
         return jsonify({'properties': [serialize_property(p) for p in props]}), 200
     except Exception:
         current_app.logger.exception('Patient properties retrieval error')
@@ -50,10 +90,11 @@ def list_properties(patient_id):
 @authenticate
 def create_property(patient_id):
     try:
-        user = request.user
-        if user.get('role') != 'doctor':
-            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
 
+        user = request.user
         data = request.get_json(silent=True) or {}
         name = data.get('name')
         description = data.get('description', '')
@@ -70,15 +111,101 @@ def create_property(patient_id):
         next_id = next_id_row['next_id'] if next_id_row else 1
 
         insert_query = """
-            INSERT INTO patient_properties (patient_id, property_id, name, description)
-            VALUES (%s, %s, %s, %s)
-            RETURNING patient_id, property_id, name, description, created_at, updated_at
+            INSERT INTO patient_properties (
+                patient_id, property_id, name, description,
+                created_by_doctor_id, updated_by_doctor_id
+            )
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING patient_id, property_id
         """
-        created = execute_query(insert_query, (patient_id, next_id, name, description), fetch_one=True)
-        return jsonify({'property': serialize_property(created)}), 201
+        created = execute_query(
+            insert_query,
+            (patient_id, next_id, name, description, doctor_id, doctor_id),
+            fetch_one=True,
+        )
+        log_data_access(
+            user['id'],
+            'patient_properties',
+            f'{patient_id}:{created["property_id"]}',
+            'CREATE',
+            request,
+        )
+        property_row = _fetch_property(patient_id, created['property_id'])
+        return jsonify({'property': serialize_property(property_row)}), 201
     except Exception:
         current_app.logger.exception('Patient property creation error')
         return jsonify({'error': FAILED_CREATE_PROPERTY_ERROR}), 500
+
+
+@patient_properties_bp.route('/<patient_id>/<int:property_id>', methods=['PATCH'])
+@authenticate
+def update_property(patient_id, property_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        user = request.user
+        data = request.get_json(silent=True) or {}
+        name = data.get('name')
+        description = data.get('description')
+        client_updated_at = data.get('updated_at')
+
+        if name is None and description is None:
+            return jsonify({'error': 'At least one of name or description is required'}), 400
+
+        if name is not None and not str(name).strip():
+            return jsonify({'error': 'name cannot be empty'}), 400
+
+        existing = _fetch_property(patient_id, property_id)
+        if not existing:
+            return jsonify({'error': 'Property not found'}), 404
+
+        if client_updated_at and existing.get('updated_at'):
+            existing_updated = existing['updated_at']
+            if isinstance(existing_updated, datetime):
+                existing_updated = existing_updated.isoformat()
+            if str(client_updated_at) < str(existing_updated):
+                return jsonify({
+                    'error': 'Note was updated by another provider',
+                    'property': serialize_property(existing),
+                }), 409
+
+        set_clauses = ['updated_at = NOW()', 'updated_by_doctor_id = %s']
+        params = [doctor_id]
+
+        if name is not None:
+            set_clauses.append('name = %s')
+            params.append(str(name).strip())
+
+        if description is not None:
+            set_clauses.append('description = %s')
+            params.append(description)
+
+        params.extend([patient_id, property_id])
+
+        update_query = f"""
+            UPDATE patient_properties
+            SET {', '.join(set_clauses)}
+            WHERE patient_id = %s AND property_id = %s
+            RETURNING patient_id, property_id
+        """
+        updated = execute_query(update_query, tuple(params), fetch_one=True)
+        if not updated:
+            return jsonify({'error': 'Property not found'}), 404
+
+        log_data_access(
+            user['id'],
+            'patient_properties',
+            f'{patient_id}:{property_id}',
+            'UPDATE',
+            request,
+        )
+        property_row = _fetch_property(patient_id, property_id)
+        return jsonify({'property': serialize_property(property_row)}), 200
+    except Exception:
+        current_app.logger.exception('Patient property update error')
+        return jsonify({'error': FAILED_UPDATE_PROPERTY_ERROR}), 500
 
 
 @patient_properties_bp.route('/<patient_id>/<int:property_id>', methods=['DELETE'])
@@ -89,6 +216,10 @@ def delete_property(patient_id, property_id):
         if user.get('role') != 'doctor':
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
 
+        existing = _fetch_property(patient_id, property_id)
+        if not existing:
+            return jsonify({'error': 'Property not found'}), 404
+
         delete_query = """
             DELETE FROM patient_properties
             WHERE patient_id = %s AND property_id = %s
@@ -98,6 +229,13 @@ def delete_property(patient_id, property_id):
         if not deleted:
             return jsonify({'error': 'Property not found'}), 404
 
+        log_data_access(
+            user['id'],
+            'patient_properties',
+            f'{patient_id}:{property_id}',
+            'DELETE',
+            request,
+        )
         return jsonify({'message': 'Property deleted'}), 200
     except Exception:
         current_app.logger.exception('Patient property deletion error')

--- a/api/tests/test_patient_properties.py
+++ b/api/tests/test_patient_properties.py
@@ -1,0 +1,171 @@
+from api.db.connection import execute_query
+from api.tests.conftest import login_as, requires_db
+
+
+def _get_patient_id():
+    patient = execute_query('SELECT id FROM patients LIMIT 1', fetch_one=True)
+    assert patient is not None, 'Expected at least one patient in seed data'
+    return patient['id']
+
+
+def _get_doctor_name(username):
+    doctor = execute_query(
+        """
+        SELECT d.first_name, d.last_name
+        FROM doctors d
+        JOIN users u ON u.id = d.user_id
+        WHERE u.username = %s
+        """,
+        (username,),
+        fetch_one=True,
+    )
+    assert doctor is not None
+    return f"{doctor['first_name']} {doctor['last_name']}"
+
+
+def _count_audit_logs(action, resource_id):
+    row = execute_query(
+        """
+        SELECT COUNT(*) AS count
+        FROM audit_logs
+        WHERE action = %s AND resource_id = %s
+        """,
+        (action, resource_id),
+        fetch_one=True,
+    )
+    return row['count'] if row else 0
+
+
+@requires_db
+def test_doctor_can_create_note_with_attribution(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+    expected_name = _get_doctor_name('doctor1')
+
+    response = client.post(
+        f'/api/patient-properties/{patient_id}',
+        headers=headers,
+        json={'name': 'Initial Assessment', 'description': 'Patient is stable.'},
+    )
+    assert response.status_code == 201, response.get_json()
+    payload = response.get_json()
+    note = payload['property']
+
+    assert note['name'] == 'Initial Assessment'
+    assert note['description'] == 'Patient is stable.'
+    assert note['created_by_name'] == expected_name
+    assert note['updated_by_name'] == expected_name
+    assert note['created_by_doctor_id'] == note['updated_by_doctor_id']
+
+
+@requires_db
+def test_doctor_can_patch_note_description(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+
+    create_response = client.post(
+        f'/api/patient-properties/{patient_id}',
+        headers=headers,
+        json={'name': 'Follow-up', 'description': 'Original note'},
+    )
+    assert create_response.status_code == 201, create_response.get_json()
+    note = create_response.get_json()['property']
+
+    patch_response = client.patch(
+        f'/api/patient-properties/{patient_id}/{note["property_id"]}',
+        headers=headers,
+        json={
+            'description': 'Updated note body',
+            'updated_at': note['updated_at'],
+        },
+    )
+    assert patch_response.status_code == 200, patch_response.get_json()
+    updated = patch_response.get_json()['property']
+
+    assert updated['description'] == 'Updated note body'
+    assert updated['updated_by_name'] == _get_doctor_name('doctor1')
+    assert updated['updated_at'] >= note['updated_at']
+
+
+@requires_db
+def test_patch_requires_doctor_role(client):
+    headers = login_as(client, 'patient1', 'Patient123!')
+    patient_id = _get_patient_id()
+
+    response = client.patch(
+        f'/api/patient-properties/{patient_id}/1',
+        headers=headers,
+        json={'description': 'Should fail'},
+    )
+    assert response.status_code == 403, response.get_json()
+
+
+@requires_db
+def test_patch_note_not_found(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+
+    response = client.patch(
+        f'/api/patient-properties/{patient_id}/99999',
+        headers=headers,
+        json={'description': 'Missing note'},
+    )
+    assert response.status_code == 404, response.get_json()
+
+
+@requires_db
+def test_list_notes_includes_provider_names(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+    expected_name = _get_doctor_name('doctor1')
+
+    create_response = client.post(
+        f'/api/patient-properties/{patient_id}',
+        headers=headers,
+        json={'name': 'List Test Note', 'description': 'Visible in list'},
+    )
+    assert create_response.status_code == 201, create_response.get_json()
+    created = create_response.get_json()['property']
+
+    list_response = client.get(
+        f'/api/patient-properties/{patient_id}',
+        headers=headers,
+    )
+    assert list_response.status_code == 200, list_response.get_json()
+    notes = list_response.get_json()['properties']
+    matched = [note for note in notes if note['property_id'] == created['property_id']]
+    assert len(matched) == 1
+    assert matched[0]['created_by_name'] == expected_name
+    assert matched[0]['updated_by_name'] == expected_name
+
+
+@requires_db
+def test_note_crud_writes_audit_log(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+
+    create_response = client.post(
+        f'/api/patient-properties/{patient_id}',
+        headers=headers,
+        json={'name': 'Audit Trail', 'description': 'Before update'},
+    )
+    assert create_response.status_code == 201, create_response.get_json()
+    note = create_response.get_json()['property']
+    resource_id = f'{patient_id}:{note["property_id"]}'
+
+    assert _count_audit_logs('DATA_CREATE', resource_id) >= 1
+
+    patch_response = client.patch(
+        f'/api/patient-properties/{patient_id}/{note["property_id"]}',
+        headers=headers,
+        json={'description': 'After update', 'updated_at': note['updated_at']},
+    )
+    assert patch_response.status_code == 200, patch_response.get_json()
+    assert _count_audit_logs('DATA_UPDATE', resource_id) >= 1
+
+    delete_response = client.delete(
+        f'/api/patient-properties/{patient_id}/{note["property_id"]}',
+        headers=headers,
+    )
+    assert delete_response.status_code == 200, delete_response.get_json()
+    assert _count_audit_logs('DATA_DELETE', resource_id) >= 1

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -135,6 +135,8 @@ CREATE TABLE IF NOT EXISTS patient_properties (
     property_id INTEGER NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
+    created_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL,
+    updated_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (patient_id, property_id)
@@ -150,3 +152,6 @@ CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at DE
 CREATE INDEX IF NOT EXISTS idx_user_sessions_token ON user_sessions(session_token);
 CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at ON user_sessions(expires_at);
+
+ALTER TABLE patient_properties ADD COLUMN IF NOT EXISTS created_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL;
+ALTER TABLE patient_properties ADD COLUMN IF NOT EXISTS updated_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -181,7 +181,51 @@ export const healthApi = {
   },
 };
 
+/**
+ * Patient properties (clinical notes) API
+ */
+export const patientPropertiesApi = {
+  async list(patientId: string) {
+    return request<{ properties: import('@/types').PatientProperty[] }>(
+      `/api/patient-properties/${patientId}`,
+      { method: 'GET' },
+    );
+  },
+
+  async create(patientId: string, payload: { name: string; description?: string }) {
+    return request<{ property: import('@/types').PatientProperty }>(
+      `/api/patient-properties/${patientId}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      },
+    );
+  },
+
+  async update(
+    patientId: string,
+    propertyId: number,
+    payload: { name?: string; description?: string; updated_at?: string },
+  ) {
+    return request<{ property: import('@/types').PatientProperty }>(
+      `/api/patient-properties/${patientId}/${propertyId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      },
+    );
+  },
+
+  async delete(patientId: string, propertyId: number) {
+    return request<{ message: string }>(
+      `/api/patient-properties/${patientId}/${propertyId}`,
+      { method: 'DELETE' },
+    );
+  },
+};
+
 export default {
   auth: authApi,
   health: healthApi,
+  patientProperties: patientPropertiesApi,
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,10 @@ export interface PatientProperty {
   property_id: number
   name: string
   description?: string | null
+  created_by_doctor_id?: string | null
+  updated_by_doctor_id?: string | null
+  created_by_name?: string | null
+  updated_by_name?: string | null
   created_at?: string
   updated_at?: string
 }

--- a/src/views/PatientsView.vue
+++ b/src/views/PatientsView.vue
@@ -81,8 +81,11 @@
               class="accordion-item"
             >
               <button class="accordion-header" @click="toggleProperty(prop.property_id)">
-                <span>{{ prop.name }}</span>
+                <span>{{ getPropertyDisplayName(prop) }}</span>
                 <span class="accordion-actions">
+                  <span v-if="getSaveStatus(prop.property_id) !== 'idle'" class="note-save-status-inline" :class="getSaveStatus(prop.property_id)">
+                    {{ saveStatusLabel(prop.property_id) }}
+                  </span>
                   <span class="toggle-indicator">
                     {{ expandedProperties.has(prop.property_id) ? '−' : '+' }}
                   </span>
@@ -90,7 +93,28 @@
                 </span>
               </button>
               <div v-if="expandedProperties.has(prop.property_id)" class="accordion-body">
-                {{ prop.description || '—' }}
+                <div class="note-editor">
+                  <label class="note-label" :for="`note-title-${prop.property_id}`">Title</label>
+                  <input
+                    :id="`note-title-${prop.property_id}`"
+                    class="note-title-input"
+                    :value="getPropertyDraft(prop).name"
+                    @input="onPropertyFieldChange(prop, 'name', ($event.target as HTMLInputElement).value)"
+                  />
+                  <label class="note-label" :for="`note-body-${prop.property_id}`">Notes</label>
+                  <textarea
+                    :id="`note-body-${prop.property_id}`"
+                    class="note-body-input"
+                    rows="5"
+                    :value="getPropertyDraft(prop).description"
+                    @input="onPropertyFieldChange(prop, 'description', ($event.target as HTMLTextAreaElement).value)"
+                  />
+                  <p class="note-audit">
+                    Created by Dr. {{ formatProviderName(prop.created_by_name) }}
+                    · Last edited by Dr. {{ formatProviderName(prop.updated_by_name) }}
+                    <span v-if="prop.updated_at"> · {{ formatDate(prop.updated_at) }}</span>
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -286,10 +310,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import type { Patient, PatientProperty, PatientDocument } from '@/types'
+import { patientPropertiesApi } from '@/api/index'
 import { logout } from '@/store'
+
+const AUTOSAVE_DELAY_MS = 800
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+interface PropertyDraft {
+  name: string
+  description: string
+  updated_at?: string
+}
 
 const patients = ref<Patient[]>([])
 const router = useRouter()
@@ -307,6 +341,10 @@ const propertyForm = ref({
   name: '',
   description: ''
 })
+const propertyDrafts = ref<Record<number, PropertyDraft>>({})
+const saveStatuses = ref<Record<number, SaveStatus>>({})
+const debounceTimers = new Map<number, ReturnType<typeof setTimeout>>()
+const pendingSaveProps = new Map<number, PatientProperty>()
 
 // Add patient state
 const showAddPatientModal = ref(false)
@@ -414,6 +452,197 @@ function cancelDelete() {
   showDeleteConfirm.value = false
 }
 
+function formatProviderName(name?: string | null) {
+  return name?.trim() || 'Unknown provider'
+}
+
+function getPropertyDraft(prop: PatientProperty): PropertyDraft {
+  const existing = propertyDrafts.value[prop.property_id]
+  if (existing) {
+    return existing
+  }
+  const draft: PropertyDraft = {
+    name: prop.name,
+    description: prop.description || '',
+    updated_at: prop.updated_at,
+  }
+  propertyDrafts.value = {
+    ...propertyDrafts.value,
+    [prop.property_id]: draft,
+  }
+  return draft
+}
+
+function getPropertyDisplayName(prop: PatientProperty) {
+  return getPropertyDraft(prop).name || prop.name
+}
+
+function getSaveStatus(propertyId: number): SaveStatus {
+  return saveStatuses.value[propertyId] || 'idle'
+}
+
+function saveStatusLabel(propertyId: number) {
+  const status = getSaveStatus(propertyId)
+  if (status === 'saving') return 'Saving…'
+  if (status === 'saved') return 'Saved'
+  if (status === 'error') return 'Save failed'
+  return ''
+}
+
+function setSaveStatus(propertyId: number, status: SaveStatus) {
+  saveStatuses.value = { ...saveStatuses.value, [propertyId]: status }
+  if (status === 'saved') {
+    setTimeout(() => {
+      if (saveStatuses.value[propertyId] === 'saved') {
+        const next = { ...saveStatuses.value }
+        delete next[propertyId]
+        saveStatuses.value = next
+      }
+    }, 2000)
+  }
+}
+
+function clearPendingSaves() {
+  for (const timer of debounceTimers.values()) {
+    clearTimeout(timer)
+  }
+  debounceTimers.clear()
+  pendingSaveProps.clear()
+  propertyDrafts.value = {}
+  saveStatuses.value = {}
+}
+
+function mergePropertyFromServer(property: PatientProperty) {
+  const idx = patientProperties.value.findIndex(p => p.property_id === property.property_id)
+  if (idx === -1) {
+    patientProperties.value = [...patientProperties.value, property]
+  } else {
+    const next = [...patientProperties.value]
+    next[idx] = property
+    patientProperties.value = next
+  }
+  propertyDrafts.value = {
+    ...propertyDrafts.value,
+    [property.property_id]: {
+      name: property.name,
+      description: property.description || '',
+      updated_at: property.updated_at,
+    },
+  }
+}
+
+function onPropertyFieldChange(prop: PatientProperty, field: 'name' | 'description', value: string) {
+  const draft = getPropertyDraft(prop)
+  propertyDrafts.value = {
+    ...propertyDrafts.value,
+    [prop.property_id]: {
+      ...draft,
+      [field]: value,
+    },
+  }
+  schedulePropertySave(prop)
+}
+
+function schedulePropertySave(prop: PatientProperty) {
+  pendingSaveProps.set(prop.property_id, prop)
+  const existingTimer = debounceTimers.get(prop.property_id)
+  if (existingTimer) {
+    clearTimeout(existingTimer)
+  }
+  const timer = setTimeout(() => {
+    debounceTimers.delete(prop.property_id)
+    const latestProp = pendingSaveProps.get(prop.property_id) || prop
+    pendingSaveProps.delete(prop.property_id)
+    void persistPropertyDraft(latestProp)
+  }, AUTOSAVE_DELAY_MS)
+  debounceTimers.set(prop.property_id, timer)
+}
+
+async function persistPropertyDraft(prop: PatientProperty, keepalive = false) {
+  if (!selectedPatientId.value) return
+
+  const draft = getPropertyDraft(prop)
+  if (!draft.name.trim()) {
+    setSaveStatus(prop.property_id, 'error')
+    return
+  }
+
+  setSaveStatus(prop.property_id, 'saving')
+
+  const payload = {
+    name: draft.name.trim(),
+    description: draft.description,
+    updated_at: draft.updated_at || prop.updated_at,
+  }
+
+  if (keepalive) {
+    const token = localStorage.getItem('sessionToken')
+    fetch(`/api/patient-properties/${selectedPatientId.value}/${prop.property_id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    }).catch(() => {})
+    return
+  }
+
+  const response = await patientPropertiesApi.update(
+    selectedPatientId.value,
+    prop.property_id,
+    payload,
+  )
+
+  if (handleApiAuthFailure(response.error)) {
+    return
+  }
+
+  if (response.error?.includes('HTTP 409')) {
+    propertiesError.value = 'Note was updated by another provider. Reloading latest version.'
+    await loadProperties()
+    return
+  }
+
+  if (response.error || !response.data?.property) {
+    setSaveStatus(prop.property_id, 'error')
+    propertiesError.value = response.error || 'Failed to save note'
+    schedulePropertySave(prop)
+    return
+  }
+
+  mergePropertyFromServer(response.data.property)
+  setSaveStatus(prop.property_id, 'saved')
+  propertiesError.value = ''
+}
+
+function flushPendingSaves() {
+  for (const [propertyId, timer] of debounceTimers.entries()) {
+    clearTimeout(timer)
+    debounceTimers.delete(propertyId)
+    const prop = pendingSaveProps.get(propertyId)
+      || patientProperties.value.find(p => p.property_id === propertyId)
+    pendingSaveProps.delete(propertyId)
+    if (prop) {
+      persistPropertyDraft(prop, true)
+    }
+  }
+}
+
+function handleBeforeUnload() {
+  flushPendingSaves()
+}
+
+function handleApiAuthFailure(error?: string): boolean {
+  if (error?.includes('HTTP 401')) {
+    logout()
+    void router.replace('/')
+    return true
+  }
+  return false
+}
+
 function formatDate(dateStr: string) {
   const date = new Date(dateStr)
   return date.toLocaleDateString('en-US', {
@@ -468,26 +697,22 @@ async function loadProperties() {
     return
   }
 
+  clearPendingSaves()
   propertiesLoading.value = true
   propertiesError.value = ''
   try {
-    const response = await fetch(`/api/patient-properties/${selectedPatientId.value}`, {
-      headers: {
-        'Authorization': `Bearer ${localStorage.getItem('sessionToken')}`
-      }
-    })
+    const response = await patientPropertiesApi.list(selectedPatientId.value)
 
-    if (await handleAuthFailure(response)) {
+    if (handleApiAuthFailure(response.error)) {
       return
     }
 
-    if (!response.ok) {
+    if (response.error) {
       propertiesError.value = 'Failed to load properties'
       return
     }
 
-    const data = await response.json()
-    patientProperties.value = data.properties || []
+    patientProperties.value = response.data?.properties || []
     expandedProperties.value = new Set()
   } catch (err) {
     console.error('Failed to load properties:', err)
@@ -501,30 +726,31 @@ async function saveProperty() {
   if (!selectedPatientId.value || !propertyForm.value.name.trim()) return
 
   try {
-    const response = await fetch(`/api/patient-properties/${selectedPatientId.value}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('sessionToken')}`
-      },
-      body: JSON.stringify({
-        name: propertyForm.value.name.trim(),
-        description: propertyForm.value.description
-      })
+    const response = await patientPropertiesApi.create(selectedPatientId.value, {
+      name: propertyForm.value.name.trim(),
+      description: propertyForm.value.description,
     })
 
-    if (await handleAuthFailure(response)) {
+    if (handleApiAuthFailure(response.error)) {
       return
     }
 
-    if (!response.ok) {
-      propertiesError.value = 'Failed to add property'
+    if (response.error || !response.data?.property) {
+      propertiesError.value = response.error || 'Failed to add property'
       return
     }
 
-    const data = await response.json()
-    patientProperties.value = [...patientProperties.value, data.property]
-    expandedProperties.value = new Set(expandedProperties.value).add(data.property.property_id)
+    const created = response.data.property
+    patientProperties.value = [...patientProperties.value, created]
+    propertyDrafts.value = {
+      ...propertyDrafts.value,
+      [created.property_id]: {
+        name: created.name,
+        description: created.description || '',
+        updated_at: created.updated_at,
+      },
+    }
+    expandedProperties.value = new Set(expandedProperties.value).add(created.property_id)
     showAddDialog.value = false
   } catch (err) {
     console.error('Failed to add property:', err)
@@ -535,29 +761,35 @@ async function saveProperty() {
 async function deleteProperty() {
   if (!selectedPatientId.value || !pendingDelete.value) return
 
-  try {
-    const response = await fetch(
-      `/api/patient-properties/${selectedPatientId.value}/${pendingDelete.value.property_id}`,
-      {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('sessionToken')}`
-        }
-      }
-    )
+  const propertyId = pendingDelete.value.property_id
+  const timer = debounceTimers.get(propertyId)
+  if (timer) {
+    clearTimeout(timer)
+    debounceTimers.delete(propertyId)
+    pendingSaveProps.delete(propertyId)
+  }
 
-    if (await handleAuthFailure(response)) {
+  try {
+    const response = await patientPropertiesApi.delete(selectedPatientId.value, propertyId)
+
+    if (handleApiAuthFailure(response.error)) {
       return
     }
 
-    if (!response.ok) {
+    if (response.error) {
       propertiesError.value = 'Failed to delete property'
       return
     }
 
     patientProperties.value = patientProperties.value.filter(
-      prop => prop.property_id !== pendingDelete.value?.property_id
+      prop => prop.property_id !== propertyId
     )
+    const nextDrafts = { ...propertyDrafts.value }
+    delete nextDrafts[propertyId]
+    propertyDrafts.value = nextDrafts
+    const nextStatuses = { ...saveStatuses.value }
+    delete nextStatuses[propertyId]
+    saveStatuses.value = nextStatuses
     cancelDelete()
   } catch (err) {
     console.error('Failed to delete property:', err)
@@ -567,9 +799,16 @@ async function deleteProperty() {
 
 onMounted(() => {
   loadPatients()
+  window.addEventListener('beforeunload', handleBeforeUnload)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('beforeunload', handleBeforeUnload)
+  clearPendingSaves()
 })
 
 watch(selectedPatientId, () => {
+  clearPendingSaves()
   loadProperties()
   loadDocuments()
 })
@@ -1051,6 +1290,57 @@ function formatFileSize(bytes: number): string {
   background: white;
   color: #374151;
   line-height: 1.4;
+}
+
+.note-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.note-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.note-title-input,
+.note-body-input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  color: #111827;
+  background: #fff;
+}
+
+.note-body-input {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.note-audit {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.note-save-status-inline {
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.note-save-status-inline.saving {
+  color: #4338ca;
+}
+
+.note-save-status-inline.saved {
+  color: #15803d;
+}
+
+.note-save-status-inline.error {
+  color: #dc2626;
 }
 
 .modal-overlay {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements debounced inline autosave for patient notes (doctor Patients view) and provider attribution for who created and last edited each note.

## Changes

### Database
- Added `created_by_doctor_id` and `updated_by_doctor_id` columns to `patient_properties` (CREATE + idempotent ALTER for existing DBs)

### Backend (`api/routes/patient_properties.py`)
- New `PATCH /api/patient-properties/:patientId/:propertyId` endpoint for note updates
- Joined doctor names in list/create/update responses (`created_by_name`, `updated_by_name`)
- Sets attribution on create and update
- Optimistic conflict detection via `updated_at` (returns 409 when stale)
- HIPAA audit logging via `log_data_access()` on VIEW/CREATE/UPDATE/DELETE

### Frontend
- `patientPropertiesApi` added to `src/api/index.ts`
- Extended `PatientProperty` type with audit fields
- `PatientsView`: inline editable title/body, 800ms debounced autosave, save status indicators, provider metadata line, best-effort flush on page unload

### Tests
- New `api/tests/test_patient_properties.py` covering attribution, PATCH, authorization, and audit log writes

## Verification

- `npm run test:backend -- api/tests/test_patient_properties.py` — all 6 tests pass
- `npm run build` — passes

## Deployment note

Existing environments should re-apply schema:

```bash
sudo -u postgres psql -d hhs_patient_portal -f server/db/schema.sql
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf18a8dd-d101-4b60-a0f2-edfc10277233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf18a8dd-d101-4b60-a0f2-edfc10277233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

