### PR TITLE
Configure cloud dev environment for Docker Compose

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    python3 \
+    python3-pip \
+    python3-venv \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 21 (matches Dockerfile.web / frontend builder)
+RUN curl -fsSL https://deb.nodesource.com/setup_21.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+########################################################
+# DOCKER INSTALLATION (docker-in-docker for cloud agents)
+########################################################
+
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y \
+    docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+    docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' > /etc/docker/daemon.json
+RUN apt-get update && apt-get install -y iptables && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+########################################################
+# UBUNTU USER (required for cloud agent git clone)
+########################################################
+
+RUN echo 'PasswordAuthentication no\nChallengeResponseAuthentication no\nUsePAM no' > /etc/ssh/sshd_config.d/disable_password_auth.conf
+RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
+RUN groupadd -f docker && usermod -aG docker ubuntu
+RUN usermod -aG sudo ubuntu
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+RUN echo "ubuntu:ubuntu" | chpasswd
+
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,14 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "Stack Logs",
+      "command": "docker compose logs -f api"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Idempotent cloud-agent install: deps + frontend build (no docker compose up here).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ ! -f .env ]; then
+  cp .env.docker.example .env
+  echo "Created .env from .env.docker.example"
+fi
+
+npm install
+
+if [ ! -d venv ]; then
+  python3 -m venv venv
+fi
+./venv/bin/pip install --upgrade pip
+./venv/bin/pip install -r requirements.txt -r requirements-dev.txt
+
+npm run build

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Start Docker daemon and bring up the production-like compose stack.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ ! -f .env ]; then
+  cp .env.docker.example .env
+fi
+
+DOCKER_CMD=(docker)
+if ! docker info >/dev/null 2>&1; then
+  if sudo docker info >/dev/null 2>&1; then
+    DOCKER_CMD=(sudo docker)
+  fi
+fi
+
+start_docker_daemon() {
+  if "${DOCKER_CMD[@]}" info >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v service >/dev/null 2>&1 && sudo service docker start >/dev/null 2>&1; then
+    :
+  else
+  # Non-systemd / cloud-agent VMs: start dockerd manually with fuse-overlayfs
+  # (required for docker-in-docker; see Cursor cloud-agent Docker docs)
+    if ! command -v fuse-overlayfs >/dev/null 2>&1; then
+      sudo apt-get update -qq
+      sudo apt-get install -y -qq fuse-overlayfs iptables >/dev/null 2>&1 || true
+      if command -v update-alternatives >/dev/null 2>&1; then
+        sudo update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
+        sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+      fi
+    fi
+
+    sudo mkdir -p /etc/docker
+    if [ ! -f /etc/docker/daemon.json ]; then
+      printf '%s\n' '{' '  "storage-driver": "fuse-overlayfs"' '}' | sudo tee /etc/docker/daemon.json >/dev/null
+    fi
+
+    if ! pgrep -x dockerd >/dev/null 2>&1; then
+      sudo nohup dockerd >/tmp/dockerd.log 2>&1 &
+    fi
+  fi
+
+  for _ in $(seq 1 45); do
+    if "${DOCKER_CMD[@]}" info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1; then
+      if ! docker info >/dev/null 2>&1; then
+        DOCKER_CMD=(sudo docker)
+      fi
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Docker daemon failed to start. See /tmp/dockerd.log" >&2
+  return 1
+}
+
+start_docker_daemon
+
+# Release 5432 if the host PostgreSQL service is still running (legacy native setup).
+if command -v ss >/dev/null 2>&1 && ss -tln | grep -q ':5432 '; then
+  if command -v pg_ctlcluster >/dev/null 2>&1; then
+    sudo pg_ctlcluster 16 main stop 2>/dev/null || true
+  fi
+fi
+
+COMPOSE_CMD=("${DOCKER_CMD[@]}" compose)
+"${COMPOSE_CMD[@]}" up -d --build
+
+for _ in $(seq 1 90); do
+  if curl -sf http://localhost:3000/health >/dev/null 2>&1; then
+    echo "Stack ready: http://localhost:80 (nginx) / http://localhost:3000 (api)"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Warning: API health check did not pass within timeout; containers may still be starting." >&2
+"${COMPOSE_CMD[@]}" ps

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,28 @@
+# Docker Compose development defaults (matches docker-compose.yml)
+# Copy to .env: cp .env.docker.example .env
+
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=hhs_patient_portal
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_SSLMODE=disable
+
+WEB_PORT=80
+API_PORT=3000
+REDIS_PORT=6379
+
+FLASK_ENV=development
+NODE_ENV=development
+FORCE_HTTPS=false
+
+SESSION_SECRET=dev-session-secret-change-me-in-production
+ALLOWED_ORIGINS=http://localhost,http://localhost:80,http://localhost:5173
+
+DOCUMENTS_STORAGE_BACKEND=local
+DOCUMENTS_LOCAL_DIR=/tmp/hhs-documents
+
+MAX_LOGIN_ATTEMPTS=5
+ACCOUNT_LOCKOUT_MINUTES=30
+SESSION_TIMEOUT_MINUTES=15
+AUDIT_LOG_RETENTION_DAYS=2555

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **HHS Patient Portal**, a full-stack app. **Local dev and production both use Docker Compose** (`docker-compose.yml` + `docker-compose.override.yml`).
+
+| Service | Port | How it runs | Notes |
+| --- | --- | --- | --- |
+| PostgreSQL 16 | 5432 | `db` service | Schema + seed applied by `db-init` on first boot |
+| Redis 7 | 6379 | `redis` service | Session/cache backing |
+| Flask API (Python) | 3000 | `api` service | Dev override mounts `./api` and runs Flask with `--reload` |
+| Nginx + Vue build | 80 | `nginx` service | Serves `dist/` and proxies `/api` → API |
+
+### Cloud agent environment
+
+Cloud agents use [`.cursor/environment.json`](.cursor/environment.json):
+
+- **Build**: [`.cursor/Dockerfile`](.cursor/Dockerfile) installs Node, Python, and Docker-in-Docker (with `fuse-overlayfs` + `iptables-legacy`)
+- **Install** ([`.cursor/install.sh`](.cursor/install.sh)): `npm install`, Python venv (for host-side pytest), `npm run build` — idempotent, no `docker compose up`
+- **Start** ([`.cursor/start.sh`](.cursor/start.sh)): `sudo service docker start` then `docker compose up -d --build`
+
+Do **not** use the legacy native-Postgres workflow (`pg_ctlcluster`, `./run-api.sh`, `npm run dev`) in cloud agents unless Docker is unavailable.
+
+### First-time / manual local setup
+
+```bash
+cp .env.docker.example .env   # or: cp .env.docker.example .env
+./dev.sh up                   # or: docker compose up -d --build
+```
+
+- App: http://localhost:80
+- API health: http://localhost:3000/health
+- Test logins (from `server/db/seed.sql`): patient `patient1` / `Patient123!`, doctor `doctor1` / `Doctor123!`
+
+### Day-to-day commands (`./dev.sh`)
+
+| Command | When to use |
+| --- | --- |
+| `./dev.sh up` | Start the full stack |
+| `./dev.sh reload` | Recreate API after `.env` changes |
+| `./dev.sh frontend` | Rebuild Vue (`npm run build`) and reload nginx |
+| `./dev.sh api` | Rebuild API image after `requirements.txt` changes |
+| `./dev.sh logs api` | Tail API logs |
+| `./dev.sh down` | Stop stack |
+
+Python file changes under `api/` auto-reload via the dev override. Vue changes require `./dev.sh frontend` (or `npm run build` + nginx reload).
+
+### `.env`
+
+- **Required and git-ignored.** Copy from [`.env.docker.example`](.env.docker.example) for compose-based dev.
+- `DB_HOST=localhost` is correct for **host-side** tools (pytest, `psql`) because compose publishes port 5432.
+- Inside the `api` container, compose sets `DB_HOST=db` automatically.
+
+### Database bootstrap
+
+On a fresh compose volume, `db-init` runs `server/db/schema.sql` and `server/db/seed.sql` automatically. To re-apply schema on an existing volume:
+
+```bash
+docker compose exec db psql -U postgres -d hhs_patient_portal -f /docker-entrypoint-initdb.d/schema.sql
+```
+
+(`seed.sql` is also in that mount; re-run only if you need seed data restored.)
+
+### Tests and build (from repo root, stack running)
+
+- Backend: `npm run test:backend` (pytest via `./venv` on host; needs DB on `localhost:5432`)
+- Frontend: `npm run test:frontend` (vitest)
+- Production build check: `npm run build`
+
+### Architecture notes
+
+- **`server/` is legacy TypeScript** — live backend is Python Flask under `api/`. `.gitignore` keeps only `server/db/*.sql`.
+- **`docker-compose.override.yml`** is applied automatically in dev (Flask dev server, live API mounts).

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -29,8 +29,8 @@ fi
 
 # Create .env if missing
 if [ ! -f .env ]; then
-    echo -e "${BLUE}📝 Creating .env...${NC}"
-    cp .env.example .env || { echo -e "${RED}❌ .env.example not found${NC}"; exit 1; }
+    echo -e "${BLUE}📝 Creating .env from .env.docker.example...${NC}"
+    cp .env.docker.example .env || cp .env.example .env || { echo -e "${RED}❌ .env.docker.example not found${NC}"; exit 1; }
 fi
 
 # Test Docker access


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconfigures the Cursor Cloud dev environment to use **Docker Compose** (matching production) instead of the legacy native PostgreSQL + venv + Vite workflow.

## Changes

### Cloud agent environment (`.cursor/`)
- **`Dockerfile`**: Ubuntu 24.04 with Node 21, Python 3, Docker CE + Compose plugin, `fuse-overlayfs`, and `iptables-legacy` for reliable docker-in-docker
- **`environment.json`**: Wires install/start scripts and a stack logs terminal
- **`install.sh`**: Idempotent `npm install`, Python venv (host pytest), `npm run build` — no `docker compose up` during install
- **`start.sh`**: Starts Docker daemon (systemd or manual with `fuse-overlayfs`), stops legacy host Postgres if it blocks port 5432, runs `docker compose up -d --build`

### Docs & config
- **`AGENTS.md`**: Rewritten for compose-first dev (`./dev.sh`, ports, test commands)
- **`.env.docker.example`**: Compose-friendly defaults (`DB_HOST=localhost`, `DB_SSLMODE=disable`, etc.)
- **`docker-build.sh`**: Prefers `.env.docker.example` when creating `.env`

## Verification

On this cloud VM after the change:
- `bash .cursor/start.sh` brings up db, redis, api, nginx
- `curl http://localhost:3000/health` → OK
- `curl http://localhost:80/` → 200
- `npm run test:backend` passes against compose Postgres on `localhost:5432`

## Note for dashboard

If a **saved personal environment snapshot** exists for this repo, it may override `.cursor/environment.json` until removed from the Cloud Agents dashboard. Delete the old snapshot to pick up the new Dockerfile-based environment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf18a8dd-d101-4b60-a0f2-edfc10277233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf18a8dd-d101-4b60-a0f2-edfc10277233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

