### PR TITLE
Use Docker Compose for the dev environment (match prod)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,23 +2,26 @@
 
 ## Cursor Cloud specific instructions
 
-This repo is the **HHS Patient Portal**, a full-stack app with three moving parts:
+This repo is the **HHS Patient Portal**. The dev environment runs on **Docker Compose** so it mirrors production (nginx + Flask API + PostgreSQL + Redis). `docker compose up` automatically merges `docker-compose.yml` (prod-like) with `docker-compose.override.yml` (dev live-reload).
 
-| Service | Port | Start command | Notes |
+| Compose service | Container | Host port | Notes |
 | --- | --- | --- | --- |
-| PostgreSQL 16 | 5432 | `sudo pg_ctlcluster 16 main start` | Not auto-started on VM boot; start it before the API. |
-| Flask API (Python) | 3000 | `./run-api.sh` (or `npm run api`) | Reads `.env`; hot-reloads on file save in dev. |
-| Vue 3 + Vite frontend | 5173 | `npm run dev` | Proxies `/api` → `http://localhost:3000` (see `vite.config.ts`). |
+| `nginx` | hhs-nginx | 80 (+443) | **Main entry point** → `http://localhost`. Serves the host `./dist` mount and proxies `/api` + `/health` to the API. |
+| `api` | hhs-api | 3000 | Flask; built from `Dockerfile`. Dev override live-mounts `./api` and runs `flask run --reload`. |
+| `db` | hhs-postgres | 5432 | `postgres:16-alpine`; data in the `postgres_data` volume. |
+| `redis` | hhs-redis | 6379 | Cache/session store. |
+| `db-init` | hhs-db-init | – | One-shot; applies `server/db/schema.sql` + `seed.sql` (idempotent), then exits. |
 
-Standard commands are documented in `README.md`, `QUICKSTART.md`, `DATABASE_SETUP.md`, and `package.json` scripts. Below are only the non-obvious caveats:
+Standard commands live in `DOCKER.md`, `DOCKER-QUICKSTART.md`, the `dev.sh` helper, and `package.json`. Non-obvious caveats:
 
-- **`.env` is required and git-ignored.** The API and `seed_users.py` need it. For local dev use `DB_HOST=localhost`, `DB_USER=postgres`, `DB_PASSWORD=postgres`, `DB_NAME=hhs_patient_portal`, and `DB_SSLMODE=disable` (the local PostgreSQL is not built with SSL, so `prefer`/`require` should be avoided). If `.env` is missing, recreate it with those values plus `ALLOWED_ORIGINS=http://localhost:5173` and `DOCUMENTS_STORAGE_BACKEND=local`.
-- **Python runs from a venv at `./venv`** (git-ignored). `npm run api`/`run-api.sh` do `source venv/bin/activate`, and tests use `./venv/bin/python`. The update script recreates/refreshes this venv.
-- **First-time DB bootstrap on a fresh database** (schema is idempotent, safe to re-run):
-  - `sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='hhs_patient_portal'" | grep -q 1 || sudo -u postgres psql -c "CREATE DATABASE hhs_patient_portal;"`
-  - `sudo -u postgres psql -d hhs_patient_portal -f server/db/schema.sql`
-  - `PYTHONPATH=$(pwd) ./venv/bin/python seed_users.py` (creates test users; idempotent).
-  - Note: `./setup-db.sh` also does this but prompts interactively for seed data, so it can block automation.
-- **Test login credentials** (from `seed_users.py`): patient `patient1` / `Patient123!`, doctor `doctor1` / `Doctor123!`.
+- **Docker daemon is NOT running on VM boot.** Start it once per session, e.g. `sudo dockerd &` (log to a file if you want to watch it). Run all docker commands with `sudo`. The daemon config in `/etc/docker/daemon.json` (`fuse-overlayfs` storage driver + `containerd-snapshotter` disabled) is required for Docker-in-Docker here and is already in place — do not switch to `overlay2`.
+- **Bring up the stack:** build the frontend first, then start compose:
+  - `npm run build` (populates `./dist`, which nginx serves via a read-only mount)
+  - `sudo docker compose up -d --build`
+  - The `dev.sh` helper wraps this: `./dev.sh up|reload|frontend|api|logs|down` (it auto-uses `sudo` when needed).
+- **Hot reload:** Python changes under `./api` auto-reload (Flask `--reload`). **Vue/frontend changes do NOT hot-reload** — nginx serves the prebuilt `./dist`, so re-run `npm run build` (then `./dev.sh frontend` to reload nginx, or just rebuild since the mount is live).
+- **`.env` is required and git-ignored** — Compose reads it for variable substitution (DB creds, secrets). For local dev `DB_PASSWORD=postgres` is enough; the compose `api` service already sets `DB_HOST=db` and `DB_SSLMODE=disable` internally, overriding host-oriented `.env` values.
+- **Port conflicts:** nothing else may bind 80/3000/5432/6379. If a host-level PostgreSQL was installed by an earlier non-Docker setup, stop it (`sudo pg_ctlcluster 16 main stop`) before `docker compose up`, or the `db` service can't bind 5432.
+- **Test login credentials** (seeded by `server/db/seed.sql`): patient `patient1` / `Patient123!`, doctor `doctor1` / `Doctor123!` (also `patient2`–`patient8`, `doctor2`–`doctor4`, all `*123!`).
+- **Tests/build:** frontend runs on the host — `npm run test:frontend` (vitest) and `npm run build` (`vue-tsc && vite build`). Backend `pytest` deps are **not** in the prod API image, so either install them in the running container (`sudo docker compose exec api pip install pytest pytest-cov && sudo docker compose exec api python -m pytest api/tests`) or run them in a throwaway host venv (`python3 -m venv venv && ./venv/bin/pip install -r requirements.txt -r requirements-dev.txt && PYTHONPATH=$PWD ./venv/bin/python -m pytest api/tests`).
 - **`server/` is legacy TypeScript and unused** — the live backend is the Python Flask API under `api/`. `.gitignore` intentionally keeps only `server/db/*.sql`.
-- Tests/build: backend `npm run test:backend` (pytest, needs the DB running), frontend `npm run test:frontend` (vitest), build `npm run build` (`vue-tsc && vite build`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reconfigures the local dev environment to run on the existing **Docker Compose** stack so it mirrors production (nginx + Flask API + PostgreSQL + Redis) instead of host-installed PostgreSQL + Flask/Vite dev servers.

- Rewrites the `## Cursor Cloud specific instructions` in `AGENTS.md` to document the compose workflow: starting `dockerd`, the required `fuse-overlayfs` daemon config, `npm run build` + `docker compose up -d --build`, the `dev.sh` helper, hot-reload behavior (Python live-reloads, Vue requires a rebuilt `./dist`), seeded credentials, port conflicts, and where to run tests.
- Simplifies the startup update script to `npm install` (host tooling for the frontend bundle nginx serves + frontend tests); the API/DB/Redis dependencies now live in containers.

No application code changed — only the existing compose files (`docker-compose.yml` + `docker-compose.override.yml`), `Dockerfile`, and `docker/nginx.conf` are used as-is.

## Verification

Brought up the full stack (`docker compose up -d --build`) — all containers healthy — and ran a hello-world flow through nginx on port 80: logged in as `patient1` and submitted a new appointment (persisted with `PENDING` status).

[docker_compose_login_and_appointment.mp4](https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocker_compose_login_and_appointment.mp4)

[Patient dashboard (compose stack, port 80)](https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompose_dashboard.webp)
[New appointment created with pending status](https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompose_appointment_confirmed.webp)

**Checks**
- `sudo docker compose up -d --build` — 4 services healthy (`db`, `redis`, `api`, `nginx`), `db-init` completed
- `curl http://localhost/health` — ok (via nginx)
- `curl -X POST http://localhost/api/auth/login` — success (nginx → Flask → Postgres)
- `curl http://localhost/` — HTTP 200 (frontend served by nginx)
- Backend tests in-container: `docker compose exec api ... pytest api/tests` — 4 passed
- GUI hello-world (login + create appointment) via `http://localhost` — success

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17d49cca-f8ab-42a9-8913-e22f418bb7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

