### PR TITLE
Add Slack-like in-app messaging for providers and patients

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -36,6 +36,7 @@ from api.routes.patient_properties import patient_properties_bp
 from api.routes.documents import documents_bp
 from api.routes.appointments import appointments_bp
 from api.routes.feature_requests import feature_requests_bp
+from api.routes.messages import messages_bp
 from api.routes.admin import admin_bp
 
 # Create Flask app
@@ -93,6 +94,7 @@ app.register_blueprint(patient_properties_bp)
 app.register_blueprint(documents_bp)
 app.register_blueprint(appointments_bp)
 app.register_blueprint(feature_requests_bp)
+app.register_blueprint(messages_bp)
 app.register_blueprint(admin_bp)
 
 # Error handlers

--- a/api/routes/messages.py
+++ b/api/routes/messages.py
@@ -1,0 +1,800 @@
+"""
+In-app messaging routes (Slack-like DMs, channels, and threads).
+HIPAA: participant-scoped access with audit logging on PHI message reads/writes.
+"""
+
+from flask import Blueprint, request, jsonify, current_app
+from datetime import datetime, timezone
+import re
+
+from api.middleware.auth import authenticate
+from api.db.connection import execute_query, DatabaseTransaction
+from api.utils.audit_log import log_data_access
+
+messages_bp = Blueprint('messages', __name__, url_prefix='/api/conversations')
+
+MAX_MESSAGE_LENGTH = 4000
+MAX_CHANNEL_TITLE_LENGTH = 80
+DEFAULT_MESSAGE_LIMIT = 50
+MAX_MESSAGE_LIMIT = 100
+INSUFFICIENT_PERMISSIONS_ERROR = 'Insufficient permissions'
+CONVERSATION_NOT_FOUND_ERROR = 'Conversation not found'
+MESSAGE_NOT_FOUND_ERROR = 'Message not found'
+
+
+def _iso(value):
+    if value is None:
+        return None
+    if hasattr(value, 'isoformat'):
+        return value.isoformat()
+    return str(value)
+
+
+def _sanitize_message_body(body: str) -> str:
+    """Keep readable punctuation while stripping HTML-ish tags and control chars."""
+    if body is None:
+        return ''
+    cleaned = re.sub(r'<[^>]*>', '', str(body))
+    cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]', '', cleaned)
+    return cleaned.strip()
+
+
+def _sanitize_title(title: str) -> str:
+    if title is None:
+        return ''
+    cleaned = re.sub(r'<[^>]*>', '', str(title))
+    cleaned = re.sub(r'[\x00-\x1f]', '', cleaned)
+    return cleaned.strip()
+
+
+def _display_name_for_user(user_id):
+    doctor = execute_query(
+        """
+        SELECT first_name, last_name, specialty
+        FROM doctors
+        WHERE user_id = %s
+        """,
+        (user_id,),
+        fetch_one=True,
+    )
+    if doctor:
+        return {
+            'display_name': f"Dr. {doctor['first_name']} {doctor['last_name']}",
+            'role': 'doctor',
+            'specialty': doctor['specialty'],
+        }
+
+    patient = execute_query(
+        """
+        SELECT first_name, last_name
+        FROM patients
+        WHERE user_id = %s
+        """,
+        (user_id,),
+        fetch_one=True,
+    )
+    if patient:
+        return {
+            'display_name': f"{patient['first_name']} {patient['last_name']}",
+            'role': 'patient',
+            'specialty': None,
+        }
+
+    user = execute_query(
+        "SELECT username, role FROM users WHERE id = %s",
+        (user_id,),
+        fetch_one=True,
+    )
+    if user:
+        return {
+            'display_name': user['username'],
+            'role': user['role'],
+            'specialty': None,
+        }
+    return {'display_name': 'Unknown', 'role': None, 'specialty': None}
+
+
+def _is_participant(conversation_id, user_id):
+    row = execute_query(
+        """
+        SELECT 1
+        FROM conversation_participants
+        WHERE conversation_id = %s AND user_id = %s
+        """,
+        (conversation_id, user_id),
+        fetch_one=True,
+    )
+    return row is not None
+
+
+def _get_conversation(conversation_id):
+    return execute_query(
+        """
+        SELECT id, type, title, created_by_user_id, created_at, updated_at
+        FROM conversations
+        WHERE id = %s
+        """,
+        (conversation_id,),
+        fetch_one=True,
+    )
+
+
+def _serialize_participant(row):
+    info = _display_name_for_user(row['user_id'])
+    return {
+        'user_id': str(row['user_id']),
+        'display_name': info['display_name'],
+        'role': info['role'],
+        'specialty': info.get('specialty'),
+        'last_read_at': _iso(row.get('last_read_at')),
+        'joined_at': _iso(row.get('joined_at')),
+    }
+
+
+def _conversation_display_title(conversation, current_user_id, participants):
+    if conversation['type'] == 'channel':
+        return conversation.get('title') or 'Channel'
+    others = [p for p in participants if p['user_id'] != str(current_user_id)]
+    if others:
+        return others[0]['display_name']
+    return 'Direct message'
+
+
+def _serialize_message(row):
+    sender = _display_name_for_user(row['sender_user_id'])
+    body = row['body']
+    if row.get('deleted_at'):
+        body = '[Message deleted]'
+    return {
+        'id': str(row['id']),
+        'conversation_id': str(row['conversation_id']),
+        'sender_user_id': str(row['sender_user_id']),
+        'sender_name': sender['display_name'],
+        'sender_role': sender['role'],
+        'parent_message_id': str(row['parent_message_id']) if row.get('parent_message_id') else None,
+        'body': body,
+        'created_at': _iso(row['created_at']),
+        'edited_at': _iso(row.get('edited_at')),
+        'deleted_at': _iso(row.get('deleted_at')),
+        'reply_count': int(row.get('reply_count') or 0),
+    }
+
+
+def _find_existing_dm(user_a, user_b):
+    return execute_query(
+        """
+        SELECT c.id
+        FROM conversations c
+        WHERE c.type = 'dm'
+          AND EXISTS (
+              SELECT 1 FROM conversation_participants cp
+              WHERE cp.conversation_id = c.id AND cp.user_id = %s
+          )
+          AND EXISTS (
+              SELECT 1 FROM conversation_participants cp
+              WHERE cp.conversation_id = c.id AND cp.user_id = %s
+          )
+          AND (
+              SELECT COUNT(*) FROM conversation_participants cp
+              WHERE cp.conversation_id = c.id
+          ) = 2
+        LIMIT 1
+        """,
+        (user_a, user_b),
+        fetch_one=True,
+    )
+
+
+def _can_message_user(actor, target_user_id):
+    """Patients and doctors may only message the opposite portal role."""
+    if str(actor['id']) == str(target_user_id):
+        return False
+
+    target = execute_query(
+        """
+        SELECT id, role, is_active
+        FROM users
+        WHERE id = %s
+        """,
+        (target_user_id,),
+        fetch_one=True,
+    )
+    if not target or not target.get('is_active'):
+        return False
+
+    actor_role = actor.get('role')
+    target_role = target.get('role')
+
+    if actor_role == 'doctor' and target_role in ('patient', 'doctor'):
+        return True
+    if actor_role == 'patient' and target_role == 'doctor':
+        return True
+    return False
+
+
+def _list_participants(conversation_id):
+    rows = execute_query(
+        """
+        SELECT conversation_id, user_id, last_read_at, joined_at
+        FROM conversation_participants
+        WHERE conversation_id = %s
+        ORDER BY joined_at ASC
+        """,
+        (conversation_id,),
+        fetch_all=True,
+    ) or []
+    return [_serialize_participant(row) for row in rows]
+
+
+def _unread_count_for_user(user_id, conversation_id=None):
+    params = [user_id]
+    conversation_filter = ''
+    if conversation_id:
+        conversation_filter = 'AND cp.conversation_id = %s'
+        params.append(conversation_id)
+
+    row = execute_query(
+        f"""
+        SELECT COUNT(*) AS count
+        FROM messages m
+        JOIN conversation_participants cp
+          ON cp.conversation_id = m.conversation_id
+         AND cp.user_id = %s
+        WHERE m.deleted_at IS NULL
+          AND m.sender_user_id <> cp.user_id
+          AND (cp.last_read_at IS NULL OR m.created_at > cp.last_read_at)
+          {conversation_filter}
+        """,
+        tuple(params),
+        fetch_one=True,
+    )
+    return int(row['count']) if row else 0
+
+
+@messages_bp.route('/contacts', methods=['GET'])
+@authenticate
+def list_contacts():
+    """List users the current user can start a conversation with."""
+    try:
+        user = request.user
+        role = user.get('role')
+        if role not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+
+        if role == 'doctor':
+            rows = execute_query(
+                """
+                SELECT u.id AS user_id, u.role,
+                       COALESCE(d.first_name, p.first_name) AS first_name,
+                       COALESCE(d.last_name, p.last_name) AS last_name,
+                       d.specialty
+                FROM users u
+                LEFT JOIN doctors d ON d.user_id = u.id
+                LEFT JOIN patients p ON p.user_id = u.id
+                WHERE u.is_active = TRUE
+                  AND u.id <> %s
+                  AND u.role IN ('doctor', 'patient')
+                  AND (d.user_id IS NOT NULL OR p.user_id IS NOT NULL)
+                ORDER BY u.role DESC, last_name ASC, first_name ASC
+                """,
+                (user['id'],),
+                fetch_all=True,
+            ) or []
+        else:
+            rows = execute_query(
+                """
+                SELECT u.id AS user_id, u.role,
+                       d.first_name, d.last_name, d.specialty
+                FROM users u
+                JOIN doctors d ON d.user_id = u.id
+                WHERE u.is_active = TRUE
+                  AND u.role = 'doctor'
+                ORDER BY d.last_name ASC, d.first_name ASC
+                """,
+                fetch_all=True,
+            ) or []
+
+        contacts = []
+        for row in rows:
+            if row['role'] == 'doctor':
+                display_name = f"Dr. {row['first_name']} {row['last_name']}"
+            else:
+                display_name = f"{row['first_name']} {row['last_name']}"
+            contacts.append({
+                'user_id': str(row['user_id']),
+                'display_name': display_name,
+                'role': row['role'],
+                'specialty': row.get('specialty'),
+            })
+
+        return jsonify({'contacts': contacts}), 200
+    except Exception:
+        current_app.logger.exception('Failed to list messaging contacts')
+        return jsonify({'error': 'Failed to list contacts'}), 500
+
+
+@messages_bp.route('/unread-count', methods=['GET'])
+@authenticate
+def unread_count():
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+        return jsonify({'unread_count': _unread_count_for_user(user['id'])}), 200
+    except Exception:
+        current_app.logger.exception('Failed to get unread message count')
+        return jsonify({'error': 'Failed to get unread count'}), 500
+
+
+@messages_bp.route('', methods=['GET'])
+@authenticate
+def list_conversations():
+    """List conversations for the current user with preview + unread counts."""
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+
+        rows = execute_query(
+            """
+            SELECT c.id, c.type, c.title, c.created_by_user_id, c.created_at, c.updated_at,
+                   cp.last_read_at,
+                   (
+                       SELECT m.body
+                       FROM messages m
+                       WHERE m.conversation_id = c.id AND m.deleted_at IS NULL
+                       ORDER BY m.created_at DESC
+                       LIMIT 1
+                   ) AS last_message_body,
+                   (
+                       SELECT m.created_at
+                       FROM messages m
+                       WHERE m.conversation_id = c.id AND m.deleted_at IS NULL
+                       ORDER BY m.created_at DESC
+                       LIMIT 1
+                   ) AS last_message_at,
+                   (
+                       SELECT m.sender_user_id
+                       FROM messages m
+                       WHERE m.conversation_id = c.id AND m.deleted_at IS NULL
+                       ORDER BY m.created_at DESC
+                       LIMIT 1
+                   ) AS last_message_sender_id
+            FROM conversations c
+            JOIN conversation_participants cp
+              ON cp.conversation_id = c.id AND cp.user_id = %s
+            ORDER BY COALESCE(
+                (
+                    SELECT m.created_at
+                    FROM messages m
+                    WHERE m.conversation_id = c.id AND m.deleted_at IS NULL
+                    ORDER BY m.created_at DESC
+                    LIMIT 1
+                ),
+                c.updated_at
+            ) DESC
+            """,
+            (user['id'],),
+            fetch_all=True,
+        ) or []
+
+        conversations = []
+        for row in rows:
+            participants = _list_participants(row['id'])
+            unread = _unread_count_for_user(user['id'], row['id'])
+            last_sender_name = None
+            if row.get('last_message_sender_id'):
+                last_sender_name = _display_name_for_user(row['last_message_sender_id'])['display_name']
+
+            conversations.append({
+                'id': str(row['id']),
+                'type': row['type'],
+                'title': _conversation_display_title(row, user['id'], participants),
+                'created_by_user_id': str(row['created_by_user_id']) if row.get('created_by_user_id') else None,
+                'created_at': _iso(row['created_at']),
+                'updated_at': _iso(row['updated_at']),
+                'participants': participants,
+                'unread_count': unread,
+                'last_message': {
+                    'body': row.get('last_message_body'),
+                    'created_at': _iso(row.get('last_message_at')),
+                    'sender_name': last_sender_name,
+                } if row.get('last_message_body') else None,
+            })
+
+        log_data_access(user['id'], 'conversations', 'list', 'VIEW', request)
+        return jsonify({'conversations': conversations}), 200
+    except Exception:
+        current_app.logger.exception('Failed to list conversations')
+        return jsonify({'error': 'Failed to list conversations'}), 500
+
+
+@messages_bp.route('', methods=['POST'])
+@authenticate
+def create_conversation():
+    """
+    Create a DM or channel.
+
+    DM body: { "type": "dm", "participant_user_id": "<uuid>" }
+    Channel body: { "type": "channel", "title": "...", "participant_user_ids": ["..."] }
+    """
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+
+        data = request.get_json(silent=True) or {}
+        conv_type = (data.get('type') or '').strip().lower()
+
+        if conv_type == 'dm':
+            participant_user_id = data.get('participant_user_id')
+            if not participant_user_id:
+                return jsonify({'error': 'participant_user_id is required for DMs'}), 400
+            if not _can_message_user(user, participant_user_id):
+                return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+
+            existing = _find_existing_dm(user['id'], participant_user_id)
+            if existing:
+                conversation = _get_conversation(existing['id'])
+                participants = _list_participants(existing['id'])
+                return jsonify({
+                    'conversation': {
+                        'id': str(conversation['id']),
+                        'type': conversation['type'],
+                        'title': _conversation_display_title(conversation, user['id'], participants),
+                        'created_by_user_id': str(conversation['created_by_user_id']) if conversation.get('created_by_user_id') else None,
+                        'created_at': _iso(conversation['created_at']),
+                        'updated_at': _iso(conversation['updated_at']),
+                        'participants': participants,
+                        'unread_count': _unread_count_for_user(user['id'], conversation['id']),
+                        'last_message': None,
+                    },
+                    'created': False,
+                }), 200
+
+            with DatabaseTransaction() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO conversations (type, title, created_by_user_id)
+                    VALUES ('dm', NULL, %s)
+                    RETURNING id, type, title, created_by_user_id, created_at, updated_at
+                    """,
+                    (user['id'],),
+                )
+                conversation = cursor.fetchone()
+                for participant_id in {str(user['id']), str(participant_user_id)}:
+                    cursor.execute(
+                        """
+                        INSERT INTO conversation_participants (conversation_id, user_id, last_read_at)
+                        VALUES (%s, %s, NOW())
+                        """,
+                        (conversation['id'], participant_id),
+                    )
+
+            participants = _list_participants(conversation['id'])
+            log_data_access(user['id'], 'conversations', str(conversation['id']), 'CREATE', request)
+            return jsonify({
+                'conversation': {
+                    'id': str(conversation['id']),
+                    'type': conversation['type'],
+                    'title': _conversation_display_title(conversation, user['id'], participants),
+                    'created_by_user_id': str(conversation['created_by_user_id']),
+                    'created_at': _iso(conversation['created_at']),
+                    'updated_at': _iso(conversation['updated_at']),
+                    'participants': participants,
+                    'unread_count': 0,
+                    'last_message': None,
+                },
+                'created': True,
+            }), 201
+
+        if conv_type == 'channel':
+            if user.get('role') != 'doctor':
+                return jsonify({'error': 'Only providers can create channels'}), 403
+
+            title = _sanitize_title(data.get('title') or '')
+            if not title:
+                return jsonify({'error': 'Channel title is required'}), 400
+            if len(title) > MAX_CHANNEL_TITLE_LENGTH:
+                return jsonify({'error': f'Channel title must be {MAX_CHANNEL_TITLE_LENGTH} characters or fewer'}), 400
+
+            participant_ids = data.get('participant_user_ids') or []
+            if not isinstance(participant_ids, list):
+                return jsonify({'error': 'participant_user_ids must be a list'}), 400
+
+            resolved_ids = {str(user['id'])}
+            for raw_id in participant_ids:
+                if not _can_message_user(user, raw_id) and str(raw_id) != str(user['id']):
+                    return jsonify({'error': f'Cannot add participant {raw_id}'}), 403
+                resolved_ids.add(str(raw_id))
+
+            with DatabaseTransaction() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO conversations (type, title, created_by_user_id)
+                    VALUES ('channel', %s, %s)
+                    RETURNING id, type, title, created_by_user_id, created_at, updated_at
+                    """,
+                    (title, user['id']),
+                )
+                conversation = cursor.fetchone()
+                for participant_id in resolved_ids:
+                    cursor.execute(
+                        """
+                        INSERT INTO conversation_participants (conversation_id, user_id, last_read_at)
+                        VALUES (%s, %s, NOW())
+                        """,
+                        (conversation['id'], participant_id),
+                    )
+
+            participants = _list_participants(conversation['id'])
+            log_data_access(user['id'], 'conversations', str(conversation['id']), 'CREATE', request)
+            return jsonify({
+                'conversation': {
+                    'id': str(conversation['id']),
+                    'type': conversation['type'],
+                    'title': conversation['title'],
+                    'created_by_user_id': str(conversation['created_by_user_id']),
+                    'created_at': _iso(conversation['created_at']),
+                    'updated_at': _iso(conversation['updated_at']),
+                    'participants': participants,
+                    'unread_count': 0,
+                    'last_message': None,
+                },
+                'created': True,
+            }), 201
+
+        return jsonify({'error': 'type must be "dm" or "channel"'}), 400
+    except Exception:
+        current_app.logger.exception('Failed to create conversation')
+        return jsonify({'error': 'Failed to create conversation'}), 500
+
+
+@messages_bp.route('/<conversation_id>', methods=['GET'])
+@authenticate
+def get_conversation(conversation_id):
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+        if not _is_participant(conversation_id, user['id']):
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+
+        conversation = _get_conversation(conversation_id)
+        if not conversation:
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+
+        participants = _list_participants(conversation_id)
+        log_data_access(user['id'], 'conversations', conversation_id, 'VIEW', request)
+        return jsonify({
+            'conversation': {
+                'id': str(conversation['id']),
+                'type': conversation['type'],
+                'title': _conversation_display_title(conversation, user['id'], participants),
+                'created_by_user_id': str(conversation['created_by_user_id']) if conversation.get('created_by_user_id') else None,
+                'created_at': _iso(conversation['created_at']),
+                'updated_at': _iso(conversation['updated_at']),
+                'participants': participants,
+                'unread_count': _unread_count_for_user(user['id'], conversation_id),
+            }
+        }), 200
+    except Exception:
+        current_app.logger.exception('Failed to get conversation')
+        return jsonify({'error': 'Failed to get conversation'}), 500
+
+
+@messages_bp.route('/<conversation_id>/messages', methods=['GET'])
+@authenticate
+def list_messages(conversation_id):
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+        if not _is_participant(conversation_id, user['id']):
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+
+        try:
+            limit = min(int(request.args.get('limit', DEFAULT_MESSAGE_LIMIT)), MAX_MESSAGE_LIMIT)
+        except (TypeError, ValueError):
+            limit = DEFAULT_MESSAGE_LIMIT
+
+        before = request.args.get('before')
+        parent_message_id = request.args.get('parent_message_id')
+        top_level_only = request.args.get('top_level_only', 'true').lower() != 'false'
+
+        params = [conversation_id]
+        filters = ['m.conversation_id = %s']
+
+        if parent_message_id:
+            filters.append('m.parent_message_id = %s')
+            params.append(parent_message_id)
+            top_level_only = False
+        elif top_level_only:
+            filters.append('m.parent_message_id IS NULL')
+
+        if before:
+            filters.append('m.created_at < %s')
+            params.append(before)
+
+        params.append(limit)
+        rows = execute_query(
+            f"""
+            SELECT m.id, m.conversation_id, m.sender_user_id, m.parent_message_id,
+                   m.body, m.created_at, m.edited_at, m.deleted_at,
+                   (
+                       SELECT COUNT(*)
+                       FROM messages replies
+                       WHERE replies.parent_message_id = m.id
+                         AND replies.deleted_at IS NULL
+                   ) AS reply_count
+            FROM messages m
+            WHERE {' AND '.join(filters)}
+            ORDER BY m.created_at DESC
+            LIMIT %s
+            """,
+            tuple(params),
+            fetch_all=True,
+        ) or []
+
+        # Return chronological order for the UI
+        messages = [_serialize_message(row) for row in reversed(rows)]
+        log_data_access(user['id'], 'messages', conversation_id, 'VIEW', request)
+        return jsonify({
+            'messages': messages,
+            'has_more': len(rows) == limit,
+        }), 200
+    except Exception:
+        current_app.logger.exception('Failed to list messages')
+        return jsonify({'error': 'Failed to list messages'}), 500
+
+
+@messages_bp.route('/<conversation_id>/messages', methods=['POST'])
+@authenticate
+def send_message(conversation_id):
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+        if not _is_participant(conversation_id, user['id']):
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+
+        data = request.get_json(silent=True) or {}
+        body = _sanitize_message_body(data.get('body') or '')
+        if not body:
+            return jsonify({'error': 'Message body is required'}), 400
+        if len(body) > MAX_MESSAGE_LENGTH:
+            return jsonify({'error': f'Message must be {MAX_MESSAGE_LENGTH} characters or fewer'}), 400
+
+        parent_message_id = data.get('parent_message_id')
+        if parent_message_id:
+            parent = execute_query(
+                """
+                SELECT id, conversation_id, deleted_at
+                FROM messages
+                WHERE id = %s
+                """,
+                (parent_message_id,),
+                fetch_one=True,
+            )
+            if not parent or str(parent['conversation_id']) != str(conversation_id):
+                return jsonify({'error': MESSAGE_NOT_FOUND_ERROR}), 404
+            if parent.get('deleted_at'):
+                return jsonify({'error': 'Cannot reply to a deleted message'}), 400
+
+        with DatabaseTransaction() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO messages (conversation_id, sender_user_id, parent_message_id, body)
+                VALUES (%s, %s, %s, %s)
+                RETURNING id, conversation_id, sender_user_id, parent_message_id,
+                          body, created_at, edited_at, deleted_at
+                """,
+                (conversation_id, user['id'], parent_message_id, body),
+            )
+            message = cursor.fetchone()
+            cursor.execute(
+                """
+                UPDATE conversations
+                SET updated_at = NOW()
+                WHERE id = %s
+                """,
+                (conversation_id,),
+            )
+            cursor.execute(
+                """
+                UPDATE conversation_participants
+                SET last_read_at = NOW()
+                WHERE conversation_id = %s AND user_id = %s
+                """,
+                (conversation_id, user['id']),
+            )
+
+        serialized = _serialize_message({**message, 'reply_count': 0})
+        log_data_access(user['id'], 'messages', str(message['id']), 'CREATE', request)
+        return jsonify({'message': serialized}), 201
+    except Exception:
+        current_app.logger.exception('Failed to send message')
+        return jsonify({'error': 'Failed to send message'}), 500
+
+
+@messages_bp.route('/<conversation_id>/read', methods=['PATCH'])
+@authenticate
+def mark_conversation_read(conversation_id):
+    try:
+        user = request.user
+        if user.get('role') not in ('doctor', 'patient'):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+        if not _is_participant(conversation_id, user['id']):
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+
+        execute_query(
+            """
+            UPDATE conversation_participants
+            SET last_read_at = NOW()
+            WHERE conversation_id = %s AND user_id = %s
+            """,
+            (conversation_id, user['id']),
+        )
+        return jsonify({
+            'message': 'Conversation marked as read',
+            'unread_count': 0,
+            'read_at': datetime.now(timezone.utc).isoformat(),
+        }), 200
+    except Exception:
+        current_app.logger.exception('Failed to mark conversation read')
+        return jsonify({'error': 'Failed to mark conversation as read'}), 500
+
+
+@messages_bp.route('/<conversation_id>/participants', methods=['POST'])
+@authenticate
+def add_participants(conversation_id):
+    """Add participants to a channel (providers only)."""
+    try:
+        user = request.user
+        if user.get('role') != 'doctor':
+            return jsonify({'error': 'Only providers can add channel participants'}), 403
+        if not _is_participant(conversation_id, user['id']):
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+
+        conversation = _get_conversation(conversation_id)
+        if not conversation:
+            return jsonify({'error': CONVERSATION_NOT_FOUND_ERROR}), 404
+        if conversation['type'] != 'channel':
+            return jsonify({'error': 'Participants can only be added to channels'}), 400
+
+        data = request.get_json(silent=True) or {}
+        participant_ids = data.get('participant_user_ids') or []
+        if not isinstance(participant_ids, list) or not participant_ids:
+            return jsonify({'error': 'participant_user_ids is required'}), 400
+
+        added = []
+        with DatabaseTransaction() as cursor:
+            for raw_id in participant_ids:
+                if not _can_message_user(user, raw_id):
+                    return jsonify({'error': f'Cannot add participant {raw_id}'}), 403
+                cursor.execute(
+                    """
+                    INSERT INTO conversation_participants (conversation_id, user_id, last_read_at)
+                    VALUES (%s, %s, NOW())
+                    ON CONFLICT (conversation_id, user_id) DO NOTHING
+                    RETURNING user_id
+                    """,
+                    (conversation_id, raw_id),
+                )
+                row = cursor.fetchone()
+                if row:
+                    added.append(str(row['user_id']))
+            cursor.execute(
+                "UPDATE conversations SET updated_at = NOW() WHERE id = %s",
+                (conversation_id,),
+            )
+
+        log_data_access(user['id'], 'conversations', conversation_id, 'UPDATE', request)
+        return jsonify({
+            'message': 'Participants added',
+            'added_user_ids': added,
+            'participants': _list_participants(conversation_id),
+        }), 200
+    except Exception:
+        current_app.logger.exception('Failed to add participants')
+        return jsonify({'error': 'Failed to add participants'}), 500

--- a/api/tests/test_messages.py
+++ b/api/tests/test_messages.py
@@ -1,0 +1,182 @@
+from api.db.connection import execute_query
+from api.tests.conftest import login_as, requires_db
+
+
+def _user_id(username):
+    row = execute_query(
+        'SELECT id FROM users WHERE username = %s',
+        (username,),
+        fetch_one=True,
+    )
+    assert row is not None, f'Expected seeded user {username}'
+    return str(row['id'])
+
+
+@requires_db
+def test_doctor_and_patient_can_dm_and_reply_in_thread(client):
+    doctor_headers = login_as(client, 'doctor1')
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    patient_user_id = _user_id('patient1')
+
+    create_response = client.post(
+        '/api/conversations',
+        headers=doctor_headers,
+        json={'type': 'dm', 'participant_user_id': patient_user_id},
+    )
+    assert create_response.status_code in (200, 201), create_response.get_json()
+    conversation = create_response.get_json()['conversation']
+    conversation_id = conversation['id']
+    assert conversation['type'] == 'dm'
+    assert len(conversation['participants']) == 2
+
+    send_response = client.post(
+        f'/api/conversations/{conversation_id}/messages',
+        headers=doctor_headers,
+        json={'body': 'Please confirm your medication list before Friday.'},
+    )
+    assert send_response.status_code == 201, send_response.get_json()
+    parent = send_response.get_json()['message']
+    assert parent['body'] == 'Please confirm your medication list before Friday.'
+    assert parent['parent_message_id'] is None
+
+    reply_response = client.post(
+        f'/api/conversations/{conversation_id}/messages',
+        headers=patient_headers,
+        json={
+            'body': 'Confirmed — no changes since last visit.',
+            'parent_message_id': parent['id'],
+        },
+    )
+    assert reply_response.status_code == 201, reply_response.get_json()
+    reply = reply_response.get_json()['message']
+    assert reply['parent_message_id'] == parent['id']
+
+    thread_response = client.get(
+        f'/api/conversations/{conversation_id}/messages?parent_message_id={parent["id"]}',
+        headers=doctor_headers,
+    )
+    assert thread_response.status_code == 200
+    thread_messages = thread_response.get_json()['messages']
+    assert any(msg['id'] == reply['id'] for msg in thread_messages)
+
+    list_response = client.get(
+        f'/api/conversations/{conversation_id}/messages',
+        headers=patient_headers,
+    )
+    assert list_response.status_code == 200
+    top_level = list_response.get_json()['messages']
+    matched = next(msg for msg in top_level if msg['id'] == parent['id'])
+    assert matched['reply_count'] >= 1
+
+
+@requires_db
+def test_patient_cannot_message_other_patients(client):
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    other_patient_id = _user_id('patient2')
+
+    response = client.post(
+        '/api/conversations',
+        headers=patient_headers,
+        json={'type': 'dm', 'participant_user_id': other_patient_id},
+    )
+    assert response.status_code == 403
+
+
+@requires_db
+def test_patient_cannot_create_channel(client):
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    response = client.post(
+        '/api/conversations',
+        headers=patient_headers,
+        json={'type': 'channel', 'title': 'Test Channel Blocked'},
+    )
+    assert response.status_code == 403
+
+
+@requires_db
+def test_doctor_can_create_channel_and_non_participant_cannot_read(client):
+    doctor_headers = login_as(client, 'doctor1')
+    outsider_headers = login_as(client, 'doctor3')
+    patient_user_id = _user_id('patient1')
+
+    create_response = client.post(
+        '/api/conversations',
+        headers=doctor_headers,
+        json={
+            'type': 'channel',
+            'title': 'Test Channel Care Sync',
+            'participant_user_ids': [patient_user_id],
+        },
+    )
+    assert create_response.status_code == 201, create_response.get_json()
+    conversation_id = create_response.get_json()['conversation']['id']
+
+    send_response = client.post(
+        f'/api/conversations/{conversation_id}/messages',
+        headers=doctor_headers,
+        json={'body': 'Channel kickoff note'},
+    )
+    assert send_response.status_code == 201
+
+    blocked = client.get(
+        f'/api/conversations/{conversation_id}/messages',
+        headers=outsider_headers,
+    )
+    assert blocked.status_code == 404
+
+    # Cleanup channel created by this test
+    execute_query(
+        "DELETE FROM conversations WHERE id = %s",
+        (conversation_id,),
+    )
+
+
+@requires_db
+def test_unread_count_updates_after_read(client):
+    doctor_headers = login_as(client, 'doctor1')
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    doctor_user_id = _user_id('doctor1')
+
+    create_response = client.post(
+        '/api/conversations',
+        headers=patient_headers,
+        json={'type': 'dm', 'participant_user_id': doctor_user_id},
+    )
+    assert create_response.status_code in (200, 201), create_response.get_json()
+    conversation_id = create_response.get_json()['conversation']['id']
+
+    send_response = client.post(
+        f'/api/conversations/{conversation_id}/messages',
+        headers=patient_headers,
+        json={'body': 'Quick question about my labs'},
+    )
+    assert send_response.status_code == 201
+
+    unread_before = client.get('/api/conversations/unread-count', headers=doctor_headers)
+    assert unread_before.status_code == 200
+    assert unread_before.get_json()['unread_count'] >= 1
+
+    mark_read = client.patch(
+        f'/api/conversations/{conversation_id}/read',
+        headers=doctor_headers,
+    )
+    assert mark_read.status_code == 200
+
+    conversation_unread = client.get(
+        '/api/conversations',
+        headers=doctor_headers,
+    )
+    assert conversation_unread.status_code == 200
+    conversations = conversation_unread.get_json()['conversations']
+    target = next(c for c in conversations if c['id'] == conversation_id)
+    assert target['unread_count'] == 0
+
+
+@requires_db
+def test_contacts_endpoint_returns_opposite_roles_for_patients(client):
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    response = client.get('/api/conversations/contacts', headers=patient_headers)
+    assert response.status_code == 200
+    contacts = response.get_json()['contacts']
+    assert len(contacts) >= 1
+    assert all(contact['role'] == 'doctor' for contact in contacts)

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -155,3 +155,46 @@ CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at ON user_sessions(expires
 
 ALTER TABLE patient_properties ADD COLUMN IF NOT EXISTS created_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL;
 ALTER TABLE patient_properties ADD COLUMN IF NOT EXISTS updated_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL;
+
+-- In-app messaging (Slack-like DMs, channels, and threads)
+CREATE TABLE IF NOT EXISTS conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    type TEXT NOT NULL CHECK (type IN ('dm', 'channel')),
+    title TEXT,
+    created_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT conversations_channel_title_check
+        CHECK (type = 'dm' OR (title IS NOT NULL AND length(trim(title)) > 0))
+);
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    last_read_at TIMESTAMPTZ,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (conversation_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    sender_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    parent_message_id UUID REFERENCES messages(id) ON DELETE CASCADE,
+    body TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    edited_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_type ON conversations(type);
+CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_user
+    ON conversation_participants(user_id, conversation_id);
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_created
+    ON messages(conversation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_parent
+    ON messages(parent_message_id)
+    WHERE parent_message_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_sender
+    ON messages(sender_user_id, created_at DESC);

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -232,3 +232,124 @@ WHERE NOT EXISTS (
       AND existing.title = e.title
       AND existing.event_date = e.event_date
 );
+
+-- Sample messaging: DM between doctor1 and patient1, plus a care-team channel.
+WITH doctor1_user AS (
+    SELECT id FROM users WHERE username = 'doctor1' LIMIT 1
+),
+patient1_user AS (
+    SELECT id FROM users WHERE username = 'patient1' LIMIT 1
+),
+doctor2_user AS (
+    SELECT id FROM users WHERE username = 'doctor2' LIMIT 1
+),
+existing_dm AS (
+    SELECT c.id
+    FROM conversations c
+    WHERE c.type = 'dm'
+      AND EXISTS (
+          SELECT 1 FROM conversation_participants cp
+          JOIN doctor1_user d1 ON cp.user_id = d1.id
+          WHERE cp.conversation_id = c.id
+      )
+      AND EXISTS (
+          SELECT 1 FROM conversation_participants cp
+          JOIN patient1_user p1 ON cp.user_id = p1.id
+          WHERE cp.conversation_id = c.id
+      )
+    LIMIT 1
+),
+new_dm AS (
+    INSERT INTO conversations (type, title, created_by_user_id)
+    SELECT 'dm', NULL, d1.id
+    FROM doctor1_user d1
+    WHERE NOT EXISTS (SELECT 1 FROM existing_dm)
+    RETURNING id, created_by_user_id
+),
+resolved_dm AS (
+    SELECT id FROM existing_dm
+    UNION ALL
+    SELECT id FROM new_dm
+),
+dm_participants AS (
+    INSERT INTO conversation_participants (conversation_id, user_id, last_read_at)
+    SELECT rd.id, u.id, NOW()
+    FROM resolved_dm rd
+    CROSS JOIN (
+        SELECT id FROM doctor1_user
+        UNION
+        SELECT id FROM patient1_user
+    ) u
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM conversation_participants cp
+        WHERE cp.conversation_id = rd.id AND cp.user_id = u.id
+    )
+    RETURNING conversation_id
+),
+dm_message AS (
+    INSERT INTO messages (conversation_id, sender_user_id, body)
+    SELECT rd.id, d1.id, 'Hi John — welcome to secure messaging. Reply here anytime with questions about your care.'
+    FROM resolved_dm rd
+    CROSS JOIN doctor1_user d1
+    WHERE NOT EXISTS (
+        SELECT 1 FROM messages m WHERE m.conversation_id = rd.id
+    )
+    RETURNING id
+)
+SELECT 1 FROM dm_message
+UNION ALL
+SELECT 1 FROM dm_participants
+LIMIT 1;
+
+WITH doctor1_user AS (
+    SELECT id FROM users WHERE username = 'doctor1' LIMIT 1
+),
+doctor2_user AS (
+    SELECT id FROM users WHERE username = 'doctor2' LIMIT 1
+),
+patient1_user AS (
+    SELECT id FROM users WHERE username = 'patient1' LIMIT 1
+),
+existing_channel AS (
+    SELECT id FROM conversations
+    WHERE type = 'channel' AND title = 'Care Team — Smith'
+    LIMIT 1
+),
+new_channel AS (
+    INSERT INTO conversations (type, title, created_by_user_id)
+    SELECT 'channel', 'Care Team — Smith', d1.id
+    FROM doctor1_user d1
+    WHERE NOT EXISTS (SELECT 1 FROM existing_channel)
+    RETURNING id
+),
+resolved_channel AS (
+    SELECT id FROM existing_channel
+    UNION ALL
+    SELECT id FROM new_channel
+)
+INSERT INTO conversation_participants (conversation_id, user_id, last_read_at)
+SELECT rc.id, u.id, NOW()
+FROM resolved_channel rc
+CROSS JOIN (
+    SELECT id FROM doctor1_user
+    UNION
+    SELECT id FROM doctor2_user
+    UNION
+    SELECT id FROM patient1_user
+) u
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM conversation_participants cp
+    WHERE cp.conversation_id = rc.id AND cp.user_id = u.id
+);
+
+INSERT INTO messages (conversation_id, sender_user_id, body)
+SELECT c.id, d1.id, 'Care team channel for coordinating John Smith''s follow-up plan.'
+FROM conversations c
+CROSS JOIN (SELECT id FROM users WHERE username = 'doctor1' LIMIT 1) d1
+WHERE c.type = 'channel'
+  AND c.title = 'Care Team — Smith'
+  AND NOT EXISTS (
+      SELECT 1 FROM messages m WHERE m.conversation_id = c.id
+  );

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,15 @@
           </button>
           <span v-if="adminSession" class="admin-role-badge">ADMIN</span>
           <span class="user-name">{{ userName }}</span>
+          <RouterLink
+            v-if="isPortalMessagingUser"
+            to="/messages"
+            class="messages-header-link"
+            aria-label="Open messages"
+          >
+            Messages
+            <span v-if="unreadMessageCount > 0" class="notification-badge">{{ unreadMessageCount }}</span>
+          </RouterLink>
           <div
             v-if="isProviderUser"
             ref="providerNotificationRef"
@@ -87,7 +96,13 @@
           class="sidebar-link"
           @click="closeSidebar"
         >
-          {{ button.label }}
+          <span>{{ button.label }}</span>
+          <span
+            v-if="button.to === '/messages' && unreadMessageCount > 0"
+            class="nav-unread-badge"
+          >
+            {{ unreadMessageCount }}
+          </span>
         </RouterLink>
       </nav>
     </aside>
@@ -140,6 +155,7 @@
 import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { RouterView, RouterLink, useRoute, useRouter } from 'vue-router'
 import { logout, adminSession, clearAdminSession } from '@/store'
+import { messagesApi } from '@/api'
 
 type NavButton = {
   label: string
@@ -183,6 +199,9 @@ let providerAlertIntervalId: ReturnType<typeof globalThis.setInterval> | null = 
 
 const PROVIDER_ALERT_LOOKAHEAD_DAYS = 14
 const PROVIDER_ALERT_REFRESH_MS = 60000
+const MESSAGE_UNREAD_REFRESH_MS = 30000
+const unreadMessageCount = ref(0)
+let messageUnreadIntervalId: ReturnType<typeof globalThis.setInterval> | null = null
 
 const loadUser = () => {
   const userStr = localStorage.getItem('currentUser')
@@ -213,6 +232,7 @@ const pageTitle = computed(() => {
   if (adminSession.value) return 'HHS Admin'
   if (route.path.startsWith('/profile')) return 'My Profile'
   if (route.path.startsWith('/patients')) return 'Patients'
+  if (route.path.startsWith('/messages')) return 'Messages'
   if (route.path.startsWith('/doctor')) return 'Doctor Dashboard'
   if (route.path.startsWith('/patient')) return 'Patient Dashboard'
   return 'Hudson Health System'
@@ -225,17 +245,25 @@ const navButtons = computed<NavButton[]>(() => {
     return [
       { label: 'Home', to: '/doctor' },
       { label: 'Patients', to: '/patients' },
+      { label: 'Messages', to: '/messages' },
       { label: 'Profile', to: '/profile' }
     ]
   }
   if (currentUser.value.role === 'patient') {
     return [
       { label: 'Home', to: '/patient' },
+      { label: 'Messages', to: '/messages' },
       { label: 'Check In', to: '/checkin' },
       { label: 'Profile', to: '/profile' }
     ]
   }
   return []
+})
+
+const isPortalMessagingUser = computed(() => {
+  return !!currentUser.value
+    && !adminSession.value
+    && (currentUser.value.role === 'doctor' || currentUser.value.role === 'patient')
 })
 
 const showFeatureRequestButton = computed(() => {
@@ -326,6 +354,33 @@ function startProviderAlertPolling() {
   }, PROVIDER_ALERT_REFRESH_MS)
 }
 
+function stopMessageUnreadPolling() {
+  if (messageUnreadIntervalId !== null) {
+    globalThis.clearInterval(messageUnreadIntervalId)
+    messageUnreadIntervalId = null
+  }
+}
+
+function startMessageUnreadPolling() {
+  stopMessageUnreadPolling()
+  messageUnreadIntervalId = globalThis.setInterval(() => {
+    loadUnreadMessageCount()
+  }, MESSAGE_UNREAD_REFRESH_MS)
+}
+
+async function loadUnreadMessageCount() {
+  if (!isPortalMessagingUser.value) {
+    unreadMessageCount.value = 0
+    return
+  }
+
+  const response = await messagesApi.getUnreadCount()
+  if (response.error || !response.data) {
+    return
+  }
+  unreadMessageCount.value = response.data.unread_count || 0
+}
+
 function markProviderAlertsAsRead() {
   if (providerAlerts.value.length === 0) {
     return
@@ -376,7 +431,7 @@ async function loadProviderAlerts() {
       `/api/events?start_date=${formatDateForApi(startDate)}&end_date=${formatDateForApi(endDate)}`,
       {
         headers: {
-          Authorization: `******'sessionToken')}`,
+          Authorization: `Bearer ${localStorage.getItem('sessionToken')}`,
         },
       }
     )
@@ -505,6 +560,10 @@ onMounted(() => {
     loadProviderAlerts()
     startProviderAlertPolling()
   }
+  if (isPortalMessagingUser.value) {
+    loadUnreadMessageCount()
+    startMessageUnreadPolling()
+  }
   globalThis.document.addEventListener('click', handleClickOutsideNotifications)
 })
 
@@ -517,6 +576,9 @@ watch(
     loadReadProviderAlertIds()
     if (isProviderUser.value) {
       loadProviderAlerts()
+    }
+    if (isPortalMessagingUser.value) {
+      loadUnreadMessageCount()
     }
   }
 )
@@ -538,8 +600,23 @@ watch(
   { immediate: false }
 )
 
+watch(
+  isPortalMessagingUser,
+  (canMessage) => {
+    if (canMessage) {
+      loadUnreadMessageCount()
+      startMessageUnreadPolling()
+      return
+    }
+    stopMessageUnreadPolling()
+    unreadMessageCount.value = 0
+  },
+  { immediate: false }
+)
+
 onBeforeUnmount(() => {
   stopProviderAlertPolling()
+  stopMessageUnreadPolling()
   globalThis.document.removeEventListener('click', handleClickOutsideNotifications)
 })
 </script>
@@ -643,7 +720,10 @@ body {
 }
 
 .sidebar-link {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   padding: 0.7rem 0.85rem;
   color: rgba(255, 255, 255, 0.9);
   text-decoration: none;
@@ -659,6 +739,38 @@ body {
   background: rgba(255, 255, 255, 0.2);
   border-color: rgba(255, 255, 255, 0.35);
   font-weight: 600;
+}
+
+.nav-unread-badge {
+  background: #dc2626;
+  color: white;
+  border-radius: 999px;
+  min-width: 1.25rem;
+  padding: 0.05rem 0.35rem;
+  font-size: 0.7rem;
+  text-align: center;
+  font-weight: 700;
+}
+
+.messages-header-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: rgba(255, 255, 255, 0.92);
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  position: relative;
+}
+
+.messages-header-link:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.messages-header-link .notification-badge {
+  position: static;
 }
 
 .logout-btn {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -224,8 +224,104 @@ export const patientPropertiesApi = {
   },
 };
 
+/**
+ * In-app messaging API (DMs, channels, threads)
+ */
+export const messagesApi = {
+  async listConversations() {
+    return request<{ conversations: import('@/types').Conversation[] }>(
+      '/api/conversations',
+      { method: 'GET' },
+    );
+  },
+
+  async getUnreadCount() {
+    return request<{ unread_count: number }>(
+      '/api/conversations/unread-count',
+      { method: 'GET' },
+    );
+  },
+
+  async listContacts() {
+    return request<{ contacts: import('@/types').MessagingContact[] }>(
+      '/api/conversations/contacts',
+      { method: 'GET' },
+    );
+  },
+
+  async createConversation(payload: {
+    type: 'dm' | 'channel';
+    participant_user_id?: string;
+    title?: string;
+    participant_user_ids?: string[];
+  }) {
+    return request<{
+      conversation: import('@/types').Conversation;
+      created: boolean;
+    }>('/api/conversations', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  async getConversation(conversationId: string) {
+    return request<{ conversation: import('@/types').Conversation }>(
+      `/api/conversations/${conversationId}`,
+      { method: 'GET' },
+    );
+  },
+
+  async listMessages(
+    conversationId: string,
+    options: { limit?: number; before?: string; parent_message_id?: string; top_level_only?: boolean } = {},
+  ) {
+    const params = new URLSearchParams();
+    if (options.limit) params.set('limit', String(options.limit));
+    if (options.before) params.set('before', options.before);
+    if (options.parent_message_id) params.set('parent_message_id', options.parent_message_id);
+    if (options.top_level_only === false) params.set('top_level_only', 'false');
+    const query = params.toString();
+    return request<{ messages: import('@/types').ChatMessage[]; has_more: boolean }>(
+      `/api/conversations/${conversationId}/messages${query ? `?${query}` : ''}`,
+      { method: 'GET' },
+    );
+  },
+
+  async sendMessage(
+    conversationId: string,
+    payload: { body: string; parent_message_id?: string },
+  ) {
+    return request<{ message: import('@/types').ChatMessage }>(
+      `/api/conversations/${conversationId}/messages`,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      },
+    );
+  },
+
+  async markRead(conversationId: string) {
+    return request<{ message: string; unread_count: number; read_at: string }>(
+      `/api/conversations/${conversationId}/read`,
+      { method: 'PATCH' },
+    );
+  },
+
+  async addParticipants(conversationId: string, participantUserIds: string[]) {
+    return request<{
+      message: string;
+      added_user_ids: string[];
+      participants: import('@/types').ConversationParticipant[];
+    }>(`/api/conversations/${conversationId}/participants`, {
+      method: 'POST',
+      body: JSON.stringify({ participant_user_ids: participantUserIds }),
+    });
+  },
+};
+
 export default {
   auth: authApi,
   health: healthApi,
   patientProperties: patientPropertiesApi,
+  messages: messagesApi,
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -38,6 +38,12 @@ const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: true, role: 'patient' }
   },
   {
+    path: '/messages',
+    name: 'Messages',
+    component: () => import('@/views/MessagesView.vue'),
+    meta: { requiresAuth: true }
+  },
+  {
     path: '/profile',
     name: 'Profile',
     component: () => import('@/views/ProfileView.vue'),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,3 +73,51 @@ export interface MedicalDocument {
   date: string
   content: string
 }
+
+export interface ConversationParticipant {
+  user_id: string
+  display_name: string
+  role: 'doctor' | 'patient' | string | null
+  specialty?: string | null
+  last_read_at?: string | null
+  joined_at?: string | null
+}
+
+export interface ConversationLastMessage {
+  body: string
+  created_at?: string | null
+  sender_name?: string | null
+}
+
+export interface Conversation {
+  id: string
+  type: 'dm' | 'channel'
+  title: string
+  created_by_user_id?: string | null
+  created_at?: string
+  updated_at?: string
+  participants: ConversationParticipant[]
+  unread_count: number
+  last_message?: ConversationLastMessage | null
+}
+
+export interface ChatMessage {
+  id: string
+  conversation_id: string
+  sender_user_id: string
+  sender_name: string
+  sender_role?: string | null
+  parent_message_id?: string | null
+  body: string
+  created_at: string
+  edited_at?: string | null
+  deleted_at?: string | null
+  reply_count: number
+}
+
+export interface MessagingContact {
+  user_id: string
+  display_name: string
+  role: 'doctor' | 'patient' | string
+  specialty?: string | null
+}

--- a/src/views/MessagesView.vue
+++ b/src/views/MessagesView.vue
@@ -1,0 +1,1102 @@
+<template>
+  <div class="messages-page">
+    <aside class="sidebar-pane">
+      <div class="sidebar-header">
+        <h2>Messages</h2>
+        <button class="compose-btn" type="button" @click="openCompose">+ New</button>
+      </div>
+
+      <div class="sidebar-filters">
+        <button
+          type="button"
+          class="filter-chip"
+          :class="{ active: listFilter === 'all' }"
+          @click="listFilter = 'all'"
+        >
+          All
+        </button>
+        <button
+          type="button"
+          class="filter-chip"
+          :class="{ active: listFilter === 'dm' }"
+          @click="listFilter = 'dm'"
+        >
+          Direct
+        </button>
+        <button
+          type="button"
+          class="filter-chip"
+          :class="{ active: listFilter === 'channel' }"
+          @click="listFilter = 'channel'"
+        >
+          Channels
+        </button>
+      </div>
+
+      <div v-if="conversationsLoading" class="pane-state">Loading conversations...</div>
+      <div v-else-if="conversationsError" class="pane-state error">{{ conversationsError }}</div>
+      <div v-else-if="filteredConversations.length === 0" class="pane-state">
+        No conversations yet. Start one with New.
+      </div>
+
+      <button
+        v-for="conversation in filteredConversations"
+        :key="conversation.id"
+        type="button"
+        class="conversation-item"
+        :class="{ active: conversation.id === selectedConversationId }"
+        @click="selectConversation(conversation.id)"
+      >
+        <div class="conversation-top">
+          <span class="conversation-title">
+            <span v-if="conversation.type === 'channel'" class="hash">#</span>
+            {{ conversation.title }}
+          </span>
+          <span v-if="conversation.unread_count > 0" class="unread-pill">
+            {{ conversation.unread_count }}
+          </span>
+        </div>
+        <div class="conversation-preview">
+          {{ conversation.last_message?.body || 'No messages yet' }}
+        </div>
+        <div class="conversation-meta">
+          {{ formatRelative(conversation.last_message?.created_at || conversation.updated_at) }}
+        </div>
+      </button>
+    </aside>
+
+    <section class="main-pane" :class="{ 'with-thread': !!activeThreadRoot }">
+      <template v-if="selectedConversation">
+        <header class="main-header">
+          <div>
+            <h2>
+              <span v-if="selectedConversation.type === 'channel'" class="hash">#</span>
+              {{ selectedConversation.title }}
+            </h2>
+            <p class="subtitle">
+              {{ participantSummary }}
+            </p>
+          </div>
+          <button
+            v-if="canCreateChannel && selectedConversation.type === 'channel'"
+            type="button"
+            class="secondary-btn"
+            @click="openAddPeople"
+          >
+            Add people
+          </button>
+        </header>
+
+        <div ref="messageListRef" class="message-list">
+          <div v-if="messagesLoading" class="pane-state">Loading messages...</div>
+          <div v-else-if="messagesError" class="pane-state error">{{ messagesError }}</div>
+          <div v-else-if="messages.length === 0" class="pane-state">
+            This is the beginning of the conversation.
+          </div>
+
+          <article
+            v-for="message in messages"
+            :key="message.id"
+            class="message-row"
+            :class="{ mine: message.sender_user_id === currentUserId }"
+          >
+            <div class="avatar" aria-hidden="true">
+              {{ initials(message.sender_name) }}
+            </div>
+            <div class="message-body">
+              <div class="message-meta">
+                <strong>{{ message.sender_name }}</strong>
+                <span>{{ formatTime(message.created_at) }}</span>
+              </div>
+              <p class="message-text">{{ message.body }}</p>
+              <div class="message-actions">
+                <button type="button" class="link-btn" @click="openThread(message)">
+                  {{ message.reply_count > 0 ? `${message.reply_count} replies` : 'Reply in thread' }}
+                </button>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <form class="composer" @submit.prevent="sendTopLevelMessage">
+          <textarea
+            v-model="draft"
+            rows="2"
+            :placeholder="composerPlaceholder"
+            @keydown.enter.exact.prevent="sendTopLevelMessage"
+          ></textarea>
+          <button class="primary-btn" type="submit" :disabled="sending || !draft.trim()">
+            {{ sending ? 'Sending...' : 'Send' }}
+          </button>
+        </form>
+      </template>
+
+      <div v-else class="empty-main">
+        <h2>Secure messaging</h2>
+        <p>Message your care team in real time — direct chats, channels, and threaded replies.</p>
+        <button type="button" class="primary-btn" @click="openCompose">Start a conversation</button>
+      </div>
+    </section>
+
+    <aside v-if="activeThreadRoot && selectedConversation" class="thread-pane">
+      <header class="thread-header">
+        <h3>Thread</h3>
+        <button type="button" class="icon-btn" aria-label="Close thread" @click="closeThread">✕</button>
+      </header>
+
+      <div class="thread-root">
+        <strong>{{ activeThreadRoot.sender_name }}</strong>
+        <p>{{ activeThreadRoot.body }}</p>
+      </div>
+
+      <div class="thread-replies">
+        <div v-if="threadLoading" class="pane-state">Loading thread...</div>
+        <article v-for="reply in threadReplies" :key="reply.id" class="message-row compact">
+          <div class="avatar small" aria-hidden="true">{{ initials(reply.sender_name) }}</div>
+          <div class="message-body">
+            <div class="message-meta">
+              <strong>{{ reply.sender_name }}</strong>
+              <span>{{ formatTime(reply.created_at) }}</span>
+            </div>
+            <p class="message-text">{{ reply.body }}</p>
+          </div>
+        </article>
+      </div>
+
+      <form class="composer compact" @submit.prevent="sendThreadReply">
+        <textarea
+          v-model="threadDraft"
+          rows="2"
+          placeholder="Reply in thread..."
+          @keydown.enter.exact.prevent="sendThreadReply"
+        ></textarea>
+        <button class="primary-btn" type="submit" :disabled="threadSending || !threadDraft.trim()">
+          {{ threadSending ? 'Sending...' : 'Reply' }}
+        </button>
+      </form>
+    </aside>
+
+    <div v-if="showComposeModal" class="modal-overlay" @click="closeCompose">
+      <div class="modal" @click.stop>
+        <div class="modal-header">
+          <h2>{{ composeMode === 'channel' ? 'Create channel' : 'New message' }}</h2>
+          <button type="button" class="icon-btn" @click="closeCompose">✕</button>
+        </div>
+
+        <div class="modal-content">
+          <div v-if="canCreateChannel" class="compose-tabs">
+            <button
+              type="button"
+              class="filter-chip"
+              :class="{ active: composeMode === 'dm' }"
+              @click="composeMode = 'dm'"
+            >
+              Direct message
+            </button>
+            <button
+              type="button"
+              class="filter-chip"
+              :class="{ active: composeMode === 'channel' }"
+              @click="composeMode = 'channel'"
+            >
+              Channel
+            </button>
+          </div>
+
+          <div v-if="composeMode === 'channel'" class="form-group">
+            <label for="channel-title">Channel name</label>
+            <input id="channel-title" v-model="channelTitle" type="text" maxlength="80" placeholder="e.g. Care Team — Smith" />
+          </div>
+
+          <div class="form-group">
+            <label>{{ composeMode === 'channel' ? 'Add people' : 'Message' }}</label>
+            <div v-if="contactsLoading" class="pane-state">Loading contacts...</div>
+            <div v-else class="contact-list">
+              <label
+                v-for="contact in contacts"
+                :key="contact.user_id"
+                class="contact-option"
+              >
+                <input
+                  v-if="composeMode === 'channel'"
+                  v-model="selectedContactIds"
+                  type="checkbox"
+                  :value="contact.user_id"
+                />
+                <input
+                  v-else
+                  v-model="selectedDmContactId"
+                  type="radio"
+                  name="dm-contact"
+                  :value="contact.user_id"
+                />
+                <span>
+                  <strong>{{ contact.display_name }}</strong>
+                  <small>
+                    {{ contact.role === 'doctor' ? (contact.specialty || 'Provider') : 'Patient' }}
+                  </small>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div v-if="composeError" class="pane-state error">{{ composeError }}</div>
+
+          <div class="modal-actions">
+            <button type="button" class="primary-btn" :disabled="composeSubmitting" @click="submitCompose">
+              {{ composeSubmitting ? 'Creating...' : (composeMode === 'channel' ? 'Create channel' : 'Open chat') }}
+            </button>
+            <button type="button" class="secondary-btn" :disabled="composeSubmitting" @click="closeCompose">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showAddPeopleModal" class="modal-overlay" @click="closeAddPeople">
+      <div class="modal" @click.stop>
+        <div class="modal-header">
+          <h2>Add people</h2>
+          <button type="button" class="icon-btn" @click="closeAddPeople">✕</button>
+        </div>
+        <div class="modal-content">
+          <div class="contact-list">
+            <label
+              v-for="contact in addableContacts"
+              :key="contact.user_id"
+              class="contact-option"
+            >
+              <input v-model="addPeopleIds" type="checkbox" :value="contact.user_id" />
+              <span>
+                <strong>{{ contact.display_name }}</strong>
+                <small>{{ contact.role === 'doctor' ? (contact.specialty || 'Provider') : 'Patient' }}</small>
+              </span>
+            </label>
+          </div>
+          <div v-if="addPeopleError" class="pane-state error">{{ addPeopleError }}</div>
+          <div class="modal-actions">
+            <button type="button" class="primary-btn" :disabled="addPeopleSubmitting" @click="submitAddPeople">
+              {{ addPeopleSubmitting ? 'Adding...' : 'Add' }}
+            </button>
+            <button type="button" class="secondary-btn" @click="closeAddPeople">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { formatDistanceToNow, parseISO, format } from 'date-fns'
+import { messagesApi } from '@/api'
+import type { ChatMessage, Conversation, MessagingContact } from '@/types'
+import { getCurrentUser } from '@/store'
+
+const POLL_MS = 15000
+
+const currentUser = getCurrentUser()
+const currentUserId = String(currentUser?.id || '')
+const canCreateChannel = currentUser?.role === 'doctor'
+
+const conversations = ref<Conversation[]>([])
+const conversationsLoading = ref(false)
+const conversationsError = ref('')
+const listFilter = ref<'all' | 'dm' | 'channel'>('all')
+const selectedConversationId = ref<string | null>(null)
+
+const messages = ref<ChatMessage[]>([])
+const messagesLoading = ref(false)
+const messagesError = ref('')
+const draft = ref('')
+const sending = ref(false)
+const messageListRef = ref<HTMLElement | null>(null)
+
+const activeThreadRoot = ref<ChatMessage | null>(null)
+const threadReplies = ref<ChatMessage[]>([])
+const threadLoading = ref(false)
+const threadDraft = ref('')
+const threadSending = ref(false)
+
+const showComposeModal = ref(false)
+const composeMode = ref<'dm' | 'channel'>('dm')
+const contacts = ref<MessagingContact[]>([])
+const contactsLoading = ref(false)
+const selectedDmContactId = ref('')
+const selectedContactIds = ref<string[]>([])
+const channelTitle = ref('')
+const composeError = ref('')
+const composeSubmitting = ref(false)
+
+const showAddPeopleModal = ref(false)
+const addPeopleIds = ref<string[]>([])
+const addPeopleError = ref('')
+const addPeopleSubmitting = ref(false)
+
+let pollTimer: ReturnType<typeof globalThis.setInterval> | null = null
+
+const selectedConversation = computed(() =>
+  conversations.value.find((c) => c.id === selectedConversationId.value) || null,
+)
+
+const filteredConversations = computed(() => {
+  if (listFilter.value === 'all') return conversations.value
+  return conversations.value.filter((c) => c.type === listFilter.value)
+})
+
+const participantSummary = computed(() => {
+  const conversation = selectedConversation.value
+  if (!conversation) return ''
+  const names = conversation.participants.map((p) => p.display_name)
+  if (conversation.type === 'channel') {
+    return `${names.length} members · ${names.slice(0, 3).join(', ')}${names.length > 3 ? '…' : ''}`
+  }
+  return names.filter((name) => !nameIncludesCurrentUser(name)).join(', ') || names.join(', ')
+})
+
+const composerPlaceholder = computed(() => {
+  if (!selectedConversation.value) return 'Write a message...'
+  if (selectedConversation.value.type === 'channel') {
+    return `Message #${selectedConversation.value.title}`
+  }
+  return `Message ${selectedConversation.value.title}`
+})
+
+const addableContacts = computed(() => {
+  const existing = new Set(
+    (selectedConversation.value?.participants || []).map((p) => p.user_id),
+  )
+  return contacts.value.filter((c) => !existing.has(c.user_id))
+})
+
+function nameIncludesCurrentUser(name: string): boolean {
+  const username = currentUser?.username || ''
+  const fullName = currentUser?.name || ''
+  return (!!fullName && name.includes(fullName)) || (!!username && name.toLowerCase().includes(username.toLowerCase()))
+}
+
+function initials(name: string): string {
+  const parts = (name || '?').trim().split(/\s+/).slice(0, 2)
+  return parts.map((p) => p[0]?.toUpperCase() || '').join('') || '?'
+}
+
+function formatRelative(value?: string | null): string {
+  if (!value) return ''
+  try {
+    return formatDistanceToNow(parseISO(value), { addSuffix: true })
+  } catch {
+    return ''
+  }
+}
+
+function formatTime(value?: string | null): string {
+  if (!value) return ''
+  try {
+    return format(parseISO(value), 'MMM d, h:mm a')
+  } catch {
+    return value
+  }
+}
+
+async function scrollMessagesToBottom() {
+  await nextTick()
+  const el = messageListRef.value
+  if (el) {
+    el.scrollTop = el.scrollHeight
+  }
+}
+
+async function loadConversations(options: { quiet?: boolean } = {}) {
+  if (!options.quiet) {
+    conversationsLoading.value = true
+  }
+  conversationsError.value = ''
+  const response = await messagesApi.listConversations()
+  conversationsLoading.value = false
+
+  if (response.error || !response.data) {
+    conversationsError.value = response.error || 'Failed to load conversations'
+    return
+  }
+
+  conversations.value = response.data.conversations
+  if (!selectedConversationId.value && conversations.value.length > 0) {
+    selectedConversationId.value = conversations.value[0].id
+  }
+}
+
+async function loadMessages(options: { quiet?: boolean } = {}) {
+  const conversationId = selectedConversationId.value
+  if (!conversationId) {
+    messages.value = []
+    return
+  }
+
+  if (!options.quiet) {
+    messagesLoading.value = true
+  }
+  messagesError.value = ''
+  const response = await messagesApi.listMessages(conversationId)
+  messagesLoading.value = false
+
+  if (response.error || !response.data) {
+    messagesError.value = response.error || 'Failed to load messages'
+    return
+  }
+
+  const previousCount = messages.value.length
+  messages.value = response.data.messages
+  await messagesApi.markRead(conversationId)
+
+  const conversation = conversations.value.find((c) => c.id === conversationId)
+  if (conversation) {
+    conversation.unread_count = 0
+  }
+
+  if (!options.quiet || messages.value.length !== previousCount) {
+    await scrollMessagesToBottom()
+  }
+}
+
+async function selectConversation(conversationId: string) {
+  selectedConversationId.value = conversationId
+  closeThread()
+  await loadMessages()
+}
+
+async function sendTopLevelMessage() {
+  const conversationId = selectedConversationId.value
+  const body = draft.value.trim()
+  if (!conversationId || !body || sending.value) return
+
+  sending.value = true
+  const response = await messagesApi.sendMessage(conversationId, { body })
+  sending.value = false
+
+  if (response.error || !response.data) {
+    messagesError.value = response.error || 'Failed to send message'
+    return
+  }
+
+  draft.value = ''
+  messages.value = [...messages.value, response.data.message]
+  await loadConversations({ quiet: true })
+  await scrollMessagesToBottom()
+}
+
+async function openThread(message: ChatMessage) {
+  activeThreadRoot.value = message
+  threadDraft.value = ''
+  await loadThreadReplies()
+}
+
+function closeThread() {
+  activeThreadRoot.value = null
+  threadReplies.value = []
+  threadDraft.value = ''
+}
+
+async function loadThreadReplies(options: { quiet?: boolean } = {}) {
+  const conversationId = selectedConversationId.value
+  const root = activeThreadRoot.value
+  if (!conversationId || !root) return
+
+  if (!options.quiet) {
+    threadLoading.value = true
+  }
+  const response = await messagesApi.listMessages(conversationId, {
+    parent_message_id: root.id,
+  })
+  threadLoading.value = false
+
+  if (response.error || !response.data) {
+    return
+  }
+  threadReplies.value = response.data.messages
+}
+
+async function sendThreadReply() {
+  const conversationId = selectedConversationId.value
+  const root = activeThreadRoot.value
+  const body = threadDraft.value.trim()
+  if (!conversationId || !root || !body || threadSending.value) return
+
+  threadSending.value = true
+  const response = await messagesApi.sendMessage(conversationId, {
+    body,
+    parent_message_id: root.id,
+  })
+  threadSending.value = false
+
+  if (response.error || !response.data) {
+    return
+  }
+
+  threadDraft.value = ''
+  threadReplies.value = [...threadReplies.value, response.data.message]
+  const parent = messages.value.find((m) => m.id === root.id)
+  if (parent) {
+    parent.reply_count += 1
+  }
+  await loadConversations({ quiet: true })
+}
+
+async function openCompose() {
+  showComposeModal.value = true
+  composeMode.value = 'dm'
+  composeError.value = ''
+  selectedDmContactId.value = ''
+  selectedContactIds.value = []
+  channelTitle.value = ''
+  await loadContacts()
+}
+
+function closeCompose() {
+  showComposeModal.value = false
+}
+
+async function loadContacts() {
+  contactsLoading.value = true
+  const response = await messagesApi.listContacts()
+  contactsLoading.value = false
+  if (response.error || !response.data) {
+    composeError.value = response.error || 'Failed to load contacts'
+    contacts.value = []
+    return
+  }
+  contacts.value = response.data.contacts
+}
+
+async function submitCompose() {
+  composeError.value = ''
+  composeSubmitting.value = true
+
+  let response
+  if (composeMode.value === 'channel') {
+    if (!channelTitle.value.trim()) {
+      composeError.value = 'Channel name is required'
+      composeSubmitting.value = false
+      return
+    }
+    response = await messagesApi.createConversation({
+      type: 'channel',
+      title: channelTitle.value.trim(),
+      participant_user_ids: selectedContactIds.value,
+    })
+  } else {
+    if (!selectedDmContactId.value) {
+      composeError.value = 'Select someone to message'
+      composeSubmitting.value = false
+      return
+    }
+    response = await messagesApi.createConversation({
+      type: 'dm',
+      participant_user_id: selectedDmContactId.value,
+    })
+  }
+
+  composeSubmitting.value = false
+  if (response.error || !response.data) {
+    composeError.value = response.error || 'Failed to create conversation'
+    return
+  }
+
+  closeCompose()
+  await loadConversations()
+  selectedConversationId.value = response.data.conversation.id
+  await loadMessages()
+}
+
+async function openAddPeople() {
+  addPeopleError.value = ''
+  addPeopleIds.value = []
+  showAddPeopleModal.value = true
+  if (contacts.value.length === 0) {
+    await loadContacts()
+  }
+}
+
+function closeAddPeople() {
+  showAddPeopleModal.value = false
+}
+
+async function submitAddPeople() {
+  if (!selectedConversationId.value || addPeopleIds.value.length === 0) {
+    addPeopleError.value = 'Select at least one person'
+    return
+  }
+  addPeopleSubmitting.value = true
+  const response = await messagesApi.addParticipants(
+    selectedConversationId.value,
+    addPeopleIds.value,
+  )
+  addPeopleSubmitting.value = false
+  if (response.error) {
+    addPeopleError.value = response.error
+    return
+  }
+  closeAddPeople()
+  await loadConversations({ quiet: true })
+}
+
+async function pollUpdates() {
+  await loadConversations({ quiet: true })
+  if (selectedConversationId.value) {
+    await loadMessages({ quiet: true })
+  }
+  if (activeThreadRoot.value) {
+    await loadThreadReplies({ quiet: true })
+  }
+}
+
+watch(selectedConversationId, async (id) => {
+  if (id) {
+    await loadMessages()
+  }
+})
+
+onMounted(async () => {
+  await loadConversations()
+  if (selectedConversationId.value) {
+    await loadMessages()
+  }
+  pollTimer = globalThis.setInterval(() => {
+    void pollUpdates()
+  }, POLL_MS)
+})
+
+onBeforeUnmount(() => {
+  if (pollTimer) {
+    globalThis.clearInterval(pollTimer)
+  }
+})
+</script>
+
+<style scoped>
+.messages-page {
+  --msg-bg: #f3f6fb;
+  --msg-panel: #ffffff;
+  --msg-ink: #0f172a;
+  --msg-muted: #64748b;
+  --msg-accent: #1d4ed8;
+  --msg-accent-soft: #dbeafe;
+  --msg-border: #d9e2ec;
+  --msg-mine: #eff6ff;
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  gap: 0;
+  height: calc(100vh - 64px);
+  background:
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 40%),
+    linear-gradient(180deg, #e8eef8 0%, var(--msg-bg) 45%, #eef2f7 100%);
+  color: var(--msg-ink);
+}
+
+.messages-page:has(.thread-pane) {
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr) minmax(260px, 340px);
+}
+
+.sidebar-pane,
+.main-pane,
+.thread-pane {
+  background: var(--msg-panel);
+  border-right: 1px solid var(--msg-border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.thread-pane {
+  border-right: none;
+  border-left: 1px solid var(--msg-border);
+}
+
+.sidebar-header,
+.main-header,
+.thread-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--msg-border);
+}
+
+.sidebar-header h2,
+.main-header h2,
+.thread-header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--msg-muted);
+  font-size: 0.85rem;
+}
+
+.sidebar-filters,
+.compose-tabs {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.75rem 1rem;
+  flex-wrap: wrap;
+}
+
+.filter-chip,
+.compose-btn,
+.primary-btn,
+.secondary-btn,
+.link-btn,
+.icon-btn {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+.filter-chip {
+  background: #eef2ff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.filter-chip.active {
+  background: var(--msg-accent);
+  color: white;
+}
+
+.compose-btn,
+.primary-btn {
+  background: var(--msg-accent);
+  color: white;
+  border-radius: 0.55rem;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+}
+
+.secondary-btn {
+  background: #e2e8f0;
+  color: #0f172a;
+  border-radius: 0.55rem;
+  padding: 0.55rem 0.9rem;
+}
+
+.compose-btn:hover,
+.primary-btn:hover {
+  background: #1e40af;
+}
+
+.primary-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.conversation-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #edf2f7;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+}
+
+.conversation-item:hover,
+.conversation-item.active {
+  background: var(--msg-accent-soft);
+}
+
+.conversation-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.conversation-title {
+  font-weight: 650;
+  font-size: 0.95rem;
+}
+
+.hash {
+  color: var(--msg-muted);
+  margin-right: 0.15rem;
+}
+
+.unread-pill {
+  background: #dc2626;
+  color: white;
+  border-radius: 999px;
+  min-width: 1.4rem;
+  text-align: center;
+  font-size: 0.72rem;
+  padding: 0.1rem 0.4rem;
+}
+
+.conversation-preview {
+  color: var(--msg-muted);
+  font-size: 0.82rem;
+  margin-top: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conversation-meta {
+  color: #94a3b8;
+  font-size: 0.72rem;
+  margin-top: 0.2rem;
+}
+
+.message-list,
+.thread-replies,
+.sidebar-pane {
+  overflow-y: auto;
+}
+
+.message-list {
+  flex: 1;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.message-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.75rem;
+}
+
+.message-row.mine {
+  background: var(--msg-mine);
+}
+
+.message-row.compact {
+  padding: 0.4rem 0;
+}
+
+.avatar {
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 0.65rem;
+  background: #1e3a5f;
+  color: white;
+  display: grid;
+  place-items: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.avatar.small {
+  width: 1.8rem;
+  height: 1.8rem;
+  font-size: 0.68rem;
+}
+
+.message-meta {
+  display: flex;
+  gap: 0.55rem;
+  align-items: baseline;
+  margin-bottom: 0.2rem;
+}
+
+.message-meta span {
+  color: var(--msg-muted);
+  font-size: 0.75rem;
+}
+
+.message-text {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+
+.message-actions {
+  margin-top: 0.35rem;
+}
+
+.link-btn {
+  background: transparent;
+  color: var(--msg-accent);
+  padding: 0;
+  font-size: 0.8rem;
+}
+
+.composer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem 1.1rem;
+  border-top: 1px solid var(--msg-border);
+  background: #f8fafc;
+}
+
+.composer.compact {
+  grid-template-columns: 1fr;
+}
+
+.composer textarea,
+.form-group input {
+  width: 100%;
+  border: 1px solid var(--msg-border);
+  border-radius: 0.65rem;
+  padding: 0.7rem 0.8rem;
+  font: inherit;
+  resize: vertical;
+  background: white;
+}
+
+.empty-main,
+.pane-state {
+  padding: 2rem 1.25rem;
+  color: var(--msg-muted);
+  text-align: center;
+}
+
+.empty-main h2 {
+  margin: 0 0 0.5rem;
+  color: var(--msg-ink);
+}
+
+.pane-state.error,
+.feature-request-error {
+  color: #b91c1c;
+}
+
+.thread-root {
+  padding: 1rem;
+  border-bottom: 1px solid var(--msg-border);
+  background: #f8fafc;
+}
+
+.thread-root p {
+  margin: 0.4rem 0 0;
+}
+
+.thread-replies {
+  flex: 1;
+  padding: 0.75rem 1rem;
+}
+
+.icon-btn {
+  background: transparent;
+  color: var(--msg-muted);
+  font-size: 1rem;
+  padding: 0.2rem 0.4rem;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: grid;
+  place-items: center;
+  z-index: 40;
+  padding: 1rem;
+}
+
+.modal {
+  width: min(520px, 100%);
+  background: white;
+  border-radius: 0.9rem;
+  overflow: hidden;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.25);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--msg-border);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modal-content {
+  padding: 1rem 1.1rem 1.2rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+
+.contact-list {
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--msg-border);
+  border-radius: 0.65rem;
+}
+
+.contact-option {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  padding: 0.7rem 0.8rem;
+  border-bottom: 1px solid #edf2f7;
+  cursor: pointer;
+}
+
+.contact-option:last-child {
+  border-bottom: none;
+}
+
+.contact-option span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.contact-option small {
+  color: var(--msg-muted);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+@media (max-width: 960px) {
+  .messages-page,
+  .messages-page:has(.thread-pane) {
+    grid-template-columns: 1fr;
+    height: auto;
+    min-height: calc(100vh - 64px);
+  }
+
+  .sidebar-pane {
+    max-height: 280px;
+    border-right: none;
+    border-bottom: 1px solid var(--msg-border);
+  }
+
+  .main-pane {
+    min-height: 420px;
+  }
+
+  .thread-pane {
+    border-left: none;
+    border-top: 1px solid var(--msg-border);
+    min-height: 320px;
+  }
+}
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a secure, Slack-style messaging system so providers and patients can communicate inside the portal.

### Features
- **Direct messages** between patients and providers (and provider-to-provider)
- **Channels** (provider-created) with multi-participant care-team chats
- **Threaded replies** on individual messages
- **Unread badges** in the header/nav with 30s polling
- Participant-scoped access plus HIPAA audit logging on message read/write

### Backend
- New tables: `conversations`, `conversation_participants`, `messages`
- New API blueprint at `/api/conversations` (list/create, messages, read receipts, contacts, unread count)
- Seed data includes a sample DM and “Care Team — Smith” channel
- Coverage in `api/tests/test_messages.py` (6 tests)

### Frontend
- New `/messages` route and `MessagesView.vue` (conversation list + message pane + thread panel)
- Nav links for doctors and patients
- `messagesApi` client helpers

### Testing
- Backend: `21` pytest tests passed (including messaging)
- Frontend: `npm run build` and existing Vitest suite passed

### How to try
1. Apply schema/seed (or restart `db-init` via compose)
2. Log in as `doctor1` / `Doctor123!` or `patient1` / `Patient123!`
3. Open **Messages** from the sidebar or header

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c85888-5f50-4b14-894f-2667613b4a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c85888-5f50-4b14-894f-2667613b4a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

