### PR TITLE
Upgrade Scheduling Assistant to multi-provider time grid

### DIFF
--- a/src/views/ProviderDashboard.spec.ts
+++ b/src/views/ProviderDashboard.spec.ts
@@ -9,82 +9,102 @@ function getLocalDateString(date: Date): string {
   return `${year}-${month}-${day}`
 }
 
+function mockFetch({
+  events = [],
+  doctors = []
+}: {
+  events?: Record<string, unknown>[]
+  doctors?: Record<string, unknown>[]
+} = {}) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/patients/doctors')) {
+      return {
+        ok: true,
+        json: async () => ({ doctors })
+      }
+    }
+    return {
+      ok: true,
+      json: async () => ({ events })
+    }
+  })
+}
+
 describe('ProviderDashboard.vue', () => {
   beforeEach(() => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({ events: [] })
-      }))
-    )
+    vi.stubGlobal('fetch', mockFetch())
   })
 
-  it('renders day schedule controls', async () => {
+  it('renders scheduling assistant controls', async () => {
     const wrapper = mount(ProviderDashboard)
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Provider Day Schedule')
-    expect(wrapper.text()).toContain('View provider availability across the clinic')
+    expect(wrapper.text()).toContain('Scheduling Assistant')
+    expect(wrapper.text()).toContain('Clinic-wide day board')
     expect(wrapper.find('.date-input').exists()).toBe(true)
+    expect(wrapper.find('.patient-search-input').exists()).toBe(true)
     expect(wrapper.find('.add-event-btn').exists()).toBe(true)
+    expect(wrapper.find('.schedule-board').exists()).toBe(true)
+    expect(wrapper.find('.time-axis--left').exists()).toBe(true)
   })
 
   it('shows events for selected day across providers with redacted other-provider details', async () => {
     const today = getLocalDateString(new Date())
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          events: [
-            {
-              id: 'evt-1',
-              doctor_id: 'doc-1',
-              event_type: 'meeting',
-              title: 'Morning Huddle',
-              event_date: today,
-              start_time: '08:30:00',
-              color: '#3b82f6',
-              is_all_day: false,
-              provider_name: 'Dr. Alice Smith',
-              is_own_event: true,
-              created_at: '2026-01-01T00:00:00Z',
-              updated_at: '2026-01-01T00:00:00Z'
-            },
-            {
-              id: 'apt-123',
-              doctor_id: 'doc-2',
-              event_type: 'appointment',
-              title: 'Appointment (pending)',
-              event_date: today,
-              start_time: '09:00:00',
-              color: '#f59e0b',
-              is_all_day: false,
-              provider_name: 'Dr. Bob Jones',
-              patient_name: null,
-              appointment_status: 'pending',
-              is_own_event: false,
-              created_at: '2026-01-01T00:00:00Z',
-              updated_at: '2026-01-01T00:00:00Z'
-            },
-            {
-              id: 'evt-future',
-              doctor_id: 'doc-1',
-              event_type: 'meeting',
-              title: 'Future Event',
-              event_date: '2099-01-01',
-              start_time: '10:00:00',
-              color: '#3b82f6',
-              is_all_day: false,
-              provider_name: 'Dr. Alice Smith',
-              is_own_event: true,
-              created_at: '2026-01-01T00:00:00Z',
-              updated_at: '2026-01-01T00:00:00Z'
-            }
-          ]
-        })
-      }))
+      mockFetch({
+        doctors: [
+          { id: 'doc-1', first_name: 'Alice', last_name: 'Smith' },
+          { id: 'doc-2', first_name: 'Bob', last_name: 'Jones' }
+        ],
+        events: [
+          {
+            id: 'evt-1',
+            doctor_id: 'doc-1',
+            event_type: 'meeting',
+            title: 'Morning Huddle',
+            event_date: today,
+            start_time: '08:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'apt-123',
+            doctor_id: 'doc-2',
+            event_type: 'appointment',
+            title: 'Appointment (pending)',
+            event_date: today,
+            start_time: '09:00:00',
+            color: '#f59e0b',
+            is_all_day: false,
+            provider_name: 'Bob Jones',
+            patient_name: null,
+            appointment_status: 'pending',
+            is_own_event: false,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'evt-future',
+            doctor_id: 'doc-1',
+            event_type: 'meeting',
+            title: 'Future Event',
+            event_date: '2099-01-01',
+            start_time: '10:00:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
     )
 
     const wrapper = mount(ProviderDashboard)
@@ -92,46 +112,67 @@ describe('ProviderDashboard.vue', () => {
 
     const providerColumns = wrapper.findAll('.provider-column')
     expect(providerColumns.length).toBe(2)
-    const headers = wrapper.findAll('.provider-column-header').map((node) => node.text())
-    expect(headers).toEqual(['Dr. Alice Smith', 'Dr. Bob Jones'])
 
-    const items = wrapper.findAll('.schedule-item')
+    const headers = wrapper.findAll('.provider-column-header').map((node) => node.text())
+    expect(headers).toEqual(['Alice Smith (1)', 'Bob Jones (1)'])
+
+    const items = wrapper.findAll('.schedule-block')
     expect(items.length).toBe(2)
     expect(wrapper.text()).toContain('Morning Huddle')
     expect(wrapper.text()).toContain('Appointment (pending)')
     expect(wrapper.text()).not.toContain('Jane Doe')
     expect(wrapper.text()).not.toContain('Future Event')
 
-    const otherProviderItem = wrapper.find('.schedule-item--other')
+    const otherProviderItem = wrapper.find('.schedule-block--other')
     expect(otherProviderItem.exists()).toBe(true)
-    expect(otherProviderItem.text()).not.toContain('Confirm')
-    expect(otherProviderItem.text()).not.toContain('Edit')
-    expect(otherProviderItem.text()).not.toContain('Delete')
 
-    const ownProviderItem = wrapper.findAll('.schedule-item').find((item) => !item.classes().includes('schedule-item--other'))
-    expect(ownProviderItem?.text()).toContain('Edit')
-    expect(ownProviderItem?.text()).toContain('Delete')
+    await otherProviderItem.trigger('click')
+    expect(wrapper.find('.selection-panel').exists()).toBe(true)
+    expect(wrapper.find('.selection-panel').text()).not.toContain('Confirm')
+    expect(wrapper.find('.selection-panel').text()).not.toContain('Edit')
+    expect(wrapper.find('.selection-panel').text()).not.toContain('Delete')
+
+    const ownProviderItem = wrapper.findAll('.schedule-block').find((item) => !item.classes().includes('schedule-block--other'))
+    expect(ownProviderItem).toBeTruthy()
+    await ownProviderItem!.trigger('click')
+    expect(wrapper.find('.selection-panel').text()).toContain('Edit')
+    expect(wrapper.find('.selection-panel').text()).toContain('Delete')
   })
 
   it('requests all providers when loading events', async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ events: [] })
-    }))
+    const fetchMock = mockFetch()
     vi.stubGlobal('fetch', fetchMock)
 
     mount(ProviderDashboard)
     await flushPromises()
 
     expect(fetchMock).toHaveBeenCalled()
-    const requestUrl = String(fetchMock.mock.calls[0][0])
-    expect(requestUrl).toContain('include_all_providers=true')
+    const eventRequest = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .find((url) => url.includes('/api/events'))
+    expect(eventRequest).toContain('include_all_providers=true')
   })
 
-  it('shows empty state when day has no events', async () => {
+  it('still shows provider columns when the day has no events', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        doctors: [
+          { id: 'doc-1', first_name: 'Alice', last_name: 'Smith' },
+          { id: 'doc-2', first_name: 'Bob', last_name: 'Jones' }
+        ],
+        events: []
+      })
+    )
+
     const wrapper = mount(ProviderDashboard)
     await flushPromises()
 
-    expect(wrapper.text()).toContain('No appointments or events scheduled for this day.')
+    expect(wrapper.find('.schedule-board').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('No appointments or events scheduled for this day.')
+
+    const headers = wrapper.findAll('.provider-column-header').map((node) => node.text())
+    expect(headers).toEqual(['Alice Smith (0)', 'Bob Jones (0)'])
+    expect(wrapper.findAll('.schedule-block').length).toBe(0)
   })
 })

--- a/src/views/ProviderDashboard.spec.ts
+++ b/src/views/ProviderDashboard.spec.ts
@@ -175,4 +175,234 @@ describe('ProviderDashboard.vue', () => {
     expect(headers).toEqual(['Alice Smith (0)', 'Bob Jones (0)'])
     expect(wrapper.findAll('.schedule-block').length).toBe(0)
   })
+
+  it('skips events entirely outside the clinic time window', async () => {
+    const today = getLocalDateString(new Date())
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        doctors: [{ id: 'doc-1', first_name: 'Alice', last_name: 'Smith' }],
+        events: [
+          {
+            id: 'early',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Too Early',
+            event_date: today,
+            start_time: '06:00:00',
+            end_time: '06:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'late',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Too Late',
+            event_date: today,
+            start_time: '20:30:00',
+            end_time: '21:00:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'in-window',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'In Window',
+            event_date: today,
+            start_time: '10:00:00',
+            end_time: '10:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
+    )
+
+    const wrapper = mount(ProviderDashboard)
+    await flushPromises()
+
+    expect(wrapper.findAll('.schedule-block').length).toBe(1)
+    expect(wrapper.text()).toContain('In Window')
+    expect(wrapper.text()).not.toContain('Too Early')
+    expect(wrapper.text()).not.toContain('Too Late')
+    expect(wrapper.find('.provider-column-header').text()).toContain('(1)')
+  })
+
+  it('spans all-day events across the full timed grid', async () => {
+    const today = getLocalDateString(new Date())
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        doctors: [{ id: 'doc-1', first_name: 'Alice', last_name: 'Smith' }],
+        events: [
+          {
+            id: 'all-day',
+            doctor_id: 'doc-1',
+            event_type: 'meeting',
+            title: 'Clinic Closed',
+            event_date: today,
+            color: '#f59e0b',
+            is_all_day: true,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
+    )
+
+    const wrapper = mount(ProviderDashboard)
+    await flushPromises()
+
+    const block = wrapper.find('.schedule-block--all-day')
+    expect(block.exists()).toBe(true)
+    expect(block.text()).toContain('Clinic Closed')
+    expect(block.text()).toContain('All day')
+    // 7 AM–8 PM = 13 hours = 52 slots * 18px = 936px
+    expect(block.attributes('style')).toContain('height: 936px')
+  })
+
+  it('lays overlapping events into side-by-side lanes', async () => {
+    const today = getLocalDateString(new Date())
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        doctors: [{ id: 'doc-1', first_name: 'Alice', last_name: 'Smith' }],
+        events: [
+          {
+            id: 'a',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Patient A',
+            patient_name: 'Patient A',
+            event_date: today,
+            start_time: '10:00:00',
+            end_time: '10:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'b',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Patient B',
+            patient_name: 'Patient B',
+            event_date: today,
+            start_time: '10:00:00',
+            end_time: '10:30:00',
+            color: '#10b981',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
+    )
+
+    const wrapper = mount(ProviderDashboard)
+    await flushPromises()
+
+    const blocks = wrapper.findAll('.schedule-block')
+    expect(blocks.length).toBe(2)
+    const styles = blocks.map((block) => block.attributes('style') || '')
+    expect(styles.some((style) => style.includes('left: calc(0% + 2px)'))).toBe(true)
+    expect(styles.some((style) => style.includes('left: calc(50% + 2px)'))).toBe(true)
+    expect(styles.every((style) => style.includes('width: calc(50% - 4px)'))).toBe(true)
+  })
+
+  it('keeps other-provider availability visible while searching patients', async () => {
+    const today = getLocalDateString(new Date())
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        doctors: [
+          { id: 'doc-1', first_name: 'Alice', last_name: 'Smith' },
+          { id: 'doc-2', first_name: 'Bob', last_name: 'Jones' }
+        ],
+        events: [
+          {
+            id: 'own-match',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Garcia Visit',
+            patient_name: 'Garcia, Jayla',
+            event_date: today,
+            start_time: '10:00:00',
+            end_time: '10:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'own-other',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Smith Visit',
+            patient_name: 'Smith, John',
+            event_date: today,
+            start_time: '11:00:00',
+            end_time: '11:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'other-block',
+            doctor_id: 'doc-2',
+            event_type: 'blocked_time',
+            title: 'Blocked Time',
+            event_date: today,
+            start_time: '09:00:00',
+            end_time: '09:30:00',
+            color: '#ef4444',
+            is_all_day: false,
+            provider_name: 'Bob Jones',
+            is_own_event: false,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
+    )
+
+    const wrapper = mount(ProviderDashboard)
+    await flushPromises()
+
+    await wrapper.find('.patient-search-input').setValue('Garcia')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('GARCIA, JAYLA')
+    expect(wrapper.text()).not.toContain('SMITH, JOHN')
+    expect(wrapper.text()).toContain('Blocked Time')
+    expect(wrapper.find('.provider-column-header').text()).toContain('Alice Smith (1)')
+    const headers = wrapper.findAll('.provider-column-header').map((node) => node.text())
+    expect(headers).toContain('Bob Jones (1)')
+  })
 })

--- a/src/views/ProviderDashboard.vue
+++ b/src/views/ProviderDashboard.vue
@@ -2,84 +2,175 @@
   <div class="provider-dashboard">
     <div class="dashboard-header">
       <div class="header-main">
-        <h1>Provider Day Schedule</h1>
-        <p>View provider availability across the clinic. Patient details are shown only for your own schedule.</p>
+        <h1>Scheduling Assistant</h1>
+        <p>Clinic-wide day board. Patient details are shown only for your own schedule.</p>
       </div>
-      <div class="date-navigation">
-        <button @click="previousDay" class="nav-btn">← Previous</button>
-        <button @click="goToToday" class="nav-btn">Today</button>
-        <button @click="nextDay" class="nav-btn">Next →</button>
-        <input
-          :value="selectedDate"
-          @input="onDateInput"
-          type="date"
-          class="date-input"
-          aria-label="Selected schedule day"
-        />
-        <button @click="openNewEventModal" class="btn-primary add-event-btn">Add Event</button>
+      <div class="toolbar">
+        <button @click="goToToday" class="nav-btn today-btn">Today</button>
+        <div class="date-navigation">
+          <button @click="previousDay" class="nav-btn arrow-btn" aria-label="Previous day">←</button>
+          <span class="current-date-label">{{ formattedDisplayDate }}</span>
+          <button @click="nextDay" class="nav-btn arrow-btn" aria-label="Next day">→</button>
+          <input
+            :value="selectedDate"
+            @input="onDateInput"
+            type="date"
+            class="date-input"
+            aria-label="Selected schedule day"
+          />
+        </div>
+        <div class="toolbar-actions">
+          <label class="patient-search">
+            <span class="sr-only">Search for Patient</span>
+            <input
+              v-model="patientSearch"
+              type="search"
+              class="patient-search-input"
+              placeholder="Search for Patient"
+              aria-label="Search for Patient"
+            />
+          </label>
+          <button @click="openNewEventModal" class="btn-primary add-event-btn">Add Event</button>
+        </div>
       </div>
     </div>
 
     <div class="schedule-container">
-      <div class="schedule-header">
-        <h2>{{ formatDate(currentDate, 'EEEE, MMMM d, yyyy') }}</h2>
-      </div>
-
       <div v-if="isLoading" class="status-message">Loading day schedule...</div>
       <div v-else-if="loadError" class="status-message error-message">{{ loadError }}</div>
 
-      <div v-else-if="dayEvents.length === 0" class="status-message empty-message">
-        No appointments or events scheduled for this day.
-      </div>
-
-      <div v-else class="provider-columns" @contextmenu.prevent>
-        <div v-for="provider in providerColumns" :key="provider.key" class="provider-column">
-          <div class="provider-column-header">{{ provider.label }}</div>
-          <div class="provider-events">
+      <div v-else class="schedule-board" @contextmenu.prevent>
+        <div class="board-scroll">
+          <div class="board-header-row" :style="boardGridStyle">
+            <div class="time-axis-spacer" aria-hidden="true"></div>
             <div
-              v-for="event in provider.events"
-              :key="event.id"
-              class="schedule-item"
-              :class="{ 'schedule-item--other': !event.is_own_event }"
+              v-for="provider in providerColumns"
+              :key="`header-${provider.key}`"
+              class="provider-column-header"
+              :style="providerHeaderStyle(provider)"
             >
-              <div class="event-topline">
-                <span class="event-dot" :style="{ backgroundColor: event.color }"></span>
-                <span class="event-title">{{ event.title }}</span>
+              {{ provider.label }} ({{ provider.events.length }})
+            </div>
+            <div class="time-axis-spacer" aria-hidden="true"></div>
+          </div>
+
+          <div class="board-body" :style="{ ...boardGridStyle, height: `${gridHeight}px` }">
+            <div class="time-axis time-axis--left">
+              <div
+                v-for="slot in timeSlots"
+                :key="`left-${slot.minutes}`"
+                class="time-slot-label"
+                :class="{ 'time-slot-label--hour': slot.isHour }"
+                :style="{ height: `${SLOT_HEIGHT_PX}px` }"
+              >
+                <span v-if="slot.isHour">{{ slot.hourLabel }}</span>
+                <span v-else class="minute-marker">{{ slot.minuteLabel }}</span>
               </div>
-              <div class="event-meta">
-                <span><strong>Time:</strong> {{ getEventTimeLabel(event) }}</span>
-                <span v-if="event.is_own_event && event.patient_name"><strong>Patient:</strong> {{ event.patient_name }}</span>
-                <span><strong>Type:</strong> {{ formatEventType(event.event_type) }}</span>
-                <span v-if="isAppointmentEvent(event) && getAppointmentStatus(event)">
-                  <strong>Status:</strong> {{ getAppointmentStatus(event) }}
-                </span>
+            </div>
+
+            <div
+              v-for="provider in providerColumns"
+              :key="provider.key"
+              class="provider-column"
+              :style="providerColumnStyle(provider)"
+            >
+              <div class="column-grid-lines" aria-hidden="true">
+                <div
+                  v-for="slot in timeSlots"
+                  :key="`line-${provider.key}-${slot.minutes}`"
+                  class="grid-line"
+                  :class="{ 'grid-line--hour': slot.isHour }"
+                  :style="{ height: `${SLOT_HEIGHT_PX}px` }"
+                ></div>
               </div>
-              <p v-if="event.is_own_event && event.description" class="event-description">{{ event.description }}</p>
-              <div v-if="event.is_own_event" class="actions-column">
-                <button
-                  v-if="isAppointmentEvent(event) && getAppointmentStatus(event) === 'pending'"
-                  class="confirm-btn"
-                  @click="confirmAppointment(event)"
+
+              <button
+                v-for="event in provider.events"
+                :key="event.id"
+                type="button"
+                class="schedule-block"
+                :class="scheduleBlockClasses(event)"
+                :style="scheduleBlockStyle(event, provider)"
+                @click="selectScheduleEvent(event)"
+              >
+                <div class="block-title">{{ displayEventTitle(event) }}</div>
+                <div class="block-meta">{{ getEventTimeLabel(event) }}</div>
+                <div class="block-meta">{{ formatEventType(event.event_type) }}</div>
+                <div
+                  v-if="event.is_own_event && event.description"
+                  class="block-description"
                 >
-                  Confirm
-                </button>
-                <button
-                  v-if="!isAppointmentEvent(event)"
-                  class="btn-secondary action-btn"
-                  @click="selectEvent(event)"
+                  {{ event.description }}
+                </div>
+                <div
+                  v-if="isAppointmentEvent(event) && getAppointmentStatus(event)"
+                  class="block-meta"
                 >
-                  Edit
-                </button>
-                <button
-                  v-if="!isAppointmentEvent(event)"
-                  class="btn-danger action-btn"
-                  @click="deleteEvent(event)"
-                >
-                  Delete
-                </button>
+                  {{ getAppointmentStatus(event) }}
+                </div>
+              </button>
+            </div>
+
+            <div class="time-axis time-axis--right">
+              <div
+                v-for="slot in timeSlots"
+                :key="`right-${slot.minutes}`"
+                class="time-slot-label"
+                :class="{ 'time-slot-label--hour': slot.isHour }"
+                :style="{ height: `${SLOT_HEIGHT_PX}px` }"
+              >
+                <span v-if="slot.isHour">{{ slot.hourLabel }}</span>
+                <span v-else class="minute-marker">{{ slot.minuteLabel }}</span>
               </div>
             </div>
           </div>
+        </div>
+
+        <div v-if="providerColumns.length === 0" class="status-message empty-message">
+          No providers available to display.
+        </div>
+      </div>
+
+      <div v-if="selectedEvent" class="selection-panel">
+        <div class="selection-panel-main">
+          <div class="selection-title">{{ displayEventTitle(selectedEvent) }}</div>
+          <div class="selection-meta">
+            <span>{{ getEventTimeLabel(selectedEvent) }}</span>
+            <span>{{ formatEventType(selectedEvent.event_type) }}</span>
+            <span v-if="selectedEvent.provider_name">{{ selectedEvent.provider_name }}</span>
+            <span v-if="isAppointmentEvent(selectedEvent) && getAppointmentStatus(selectedEvent)">
+              Status: {{ getAppointmentStatus(selectedEvent) }}
+            </span>
+          </div>
+          <p v-if="selectedEvent.is_own_event && selectedEvent.description" class="selection-description">
+            {{ selectedEvent.description }}
+          </p>
+        </div>
+        <div class="selection-actions">
+          <template v-if="selectedEvent.is_own_event">
+            <button
+              v-if="isAppointmentEvent(selectedEvent) && getAppointmentStatus(selectedEvent) === 'pending'"
+              class="confirm-btn"
+              @click="confirmAppointment(selectedEvent)"
+            >
+              Confirm
+            </button>
+            <button
+              v-if="!isAppointmentEvent(selectedEvent)"
+              class="btn-secondary action-btn"
+              @click="selectEvent(selectedEvent)"
+            >
+              Edit
+            </button>
+            <button
+              v-if="!isAppointmentEvent(selectedEvent)"
+              class="btn-danger action-btn"
+              @click="deleteEvent(selectedEvent)"
+            >
+              Delete
+            </button>
+          </template>
+          <button class="btn-secondary action-btn" @click="clearSelectedEvent">Close</button>
         </div>
       </div>
     </div>
@@ -185,9 +276,17 @@ interface DashboardEvent {
   updated_at: string
 }
 
+interface ClinicProvider {
+  id: string
+  first_name?: string
+  last_name?: string
+}
+
 interface ProviderColumn {
   key: string
+  doctorId: string
   label: string
+  colorIndex: number
   events: DashboardEvent[]
 }
 
@@ -203,8 +302,48 @@ interface EventForm {
   is_all_day: boolean
 }
 
+interface TimeSlot {
+  minutes: number
+  isHour: boolean
+  hourLabel: string
+  minuteLabel: string
+}
+
+const START_HOUR = 7
+const END_HOUR = 20
+const SLOT_MINUTES = 15
+const SLOT_HEIGHT_PX = 18
+const DEFAULT_DURATION_MINUTES = 30
+const GRID_START_MINUTES = START_HOUR * 60
+const GRID_END_MINUTES = END_HOUR * 60
+
+const PROVIDER_HEADER_COLORS = [
+  '#6b7280',
+  '#86efac',
+  '#fde047',
+  '#c4b5fd',
+  '#fdba74',
+  '#67e8f9',
+  '#86efac',
+  '#e7e5e4'
+]
+
+const PROVIDER_COLUMN_TINTS = [
+  '#f3f4f6',
+  '#f0fdf4',
+  '#fefce8',
+  '#f5f3ff',
+  '#fff7ed',
+  '#ecfeff',
+  '#f0fdf4',
+  '#fafaf9'
+]
+
 const currentDate = ref(new Date())
 const events = ref<DashboardEvent[]>([])
+const providers = ref<ClinicProvider[]>([])
+const patientSearch = ref('')
+const selectedEvent = ref<DashboardEvent | null>(null)
 const showEventModal = ref(false)
 const editingEvent = ref<DashboardEvent | null>(null)
 const isLoading = ref(false)
@@ -223,43 +362,116 @@ const eventForm = ref<EventForm>({
 
 const selectedDate = computed(() => formatDate(currentDate.value, 'yyyy-MM-dd'))
 
+const formattedDisplayDate = computed(() => format(currentDate.value, 'MMMM do, yyyy'))
+
+const timeSlots = computed<TimeSlot[]>(() => {
+  const slots: TimeSlot[] = []
+  for (let minutes = GRID_START_MINUTES; minutes < GRID_END_MINUTES; minutes += SLOT_MINUTES) {
+    const hour = Math.floor(minutes / 60)
+    const minute = minutes % 60
+    slots.push({
+      minutes,
+      isHour: minute === 0,
+      hourLabel: formatHourLabel(hour),
+      minuteLabel: String(minute).padStart(2, '0')
+    })
+  }
+  return slots
+})
+
+const gridHeight = computed(() => timeSlots.value.length * SLOT_HEIGHT_PX)
+
 const dayEvents = computed(() => {
   const dateStr = formatDate(currentDate.value, 'yyyy-MM-dd')
+  const query = patientSearch.value.trim().toLowerCase()
+
   return events.value
     .filter((event) => event.event_date === dateStr)
+    .filter((event) => {
+      if (!query) {
+        return true
+      }
+      if (!event.is_own_event) {
+        return false
+      }
+      const haystack = `${event.patient_name || ''} ${event.title || ''}`.toLowerCase()
+      return haystack.includes(query)
+    })
     .sort((left, right) => getSortTime(left).localeCompare(getSortTime(right)))
 })
 
 const providerColumns = computed<ProviderColumn[]>(() => {
-  const grouped = new Map<string, ProviderColumn>()
+  const eventsByDoctor = new Map<string, DashboardEvent[]>()
   for (const event of dayEvents.value) {
-    const providerLabel = event.provider_name?.trim() || 'Unknown provider'
-    const providerKey = `${event.doctor_id || 'unknown'}::${providerLabel}`
-    if (!grouped.has(providerKey)) {
-      grouped.set(providerKey, {
-        key: providerKey,
-        label: providerLabel,
-        events: []
-      })
+    const doctorId = String(event.doctor_id || 'unknown')
+    if (!eventsByDoctor.has(doctorId)) {
+      eventsByDoctor.set(doctorId, [])
     }
-    grouped.get(providerKey)?.events.push(event)
+    eventsByDoctor.get(doctorId)?.push(event)
   }
 
-  return Array.from(grouped.values())
-    .sort((left, right) => left.label.localeCompare(right.label))
-    .map((provider) => ({
-      ...provider,
-      events: [...provider.events].sort((left, right) => {
-        const timeCompare = getSortTime(left).localeCompare(getSortTime(right))
-        if (timeCompare !== 0) return timeCompare
-        return left.title.localeCompare(right.title)
-      })
-    }))
+  const columns: ProviderColumn[] = []
+  const seen = new Set<string>()
+
+  providers.value.forEach((provider, index) => {
+    const doctorId = String(provider.id)
+    seen.add(doctorId)
+    const label = formatProviderName(provider)
+    columns.push({
+      key: doctorId,
+      doctorId,
+      label,
+      colorIndex: index % PROVIDER_HEADER_COLORS.length,
+      events: sortProviderEvents(eventsByDoctor.get(doctorId) || [])
+    })
+  })
+
+  for (const [doctorId, providerEvents] of eventsByDoctor.entries()) {
+    if (seen.has(doctorId)) {
+      continue
+    }
+    const label = providerEvents[0]?.provider_name?.trim() || 'Unknown provider'
+    columns.push({
+      key: doctorId,
+      doctorId,
+      label,
+      colorIndex: columns.length % PROVIDER_HEADER_COLORS.length,
+      events: sortProviderEvents(providerEvents)
+    })
+  }
+
+  return columns.sort((left, right) => left.label.localeCompare(right.label))
 })
+
+const boardGridStyle = computed(() => ({
+  '--provider-count': String(Math.max(providerColumns.value.length, 1))
+}))
 
 function formatDate(date: Date | string, fmt: string): string {
   const parsed = typeof date === 'string' ? parse(date, 'yyyy-MM-dd', new Date()) : date
   return format(parsed, fmt)
+}
+
+function formatProviderName(provider: ClinicProvider): string {
+  const name = `${provider.first_name || ''} ${provider.last_name || ''}`.trim()
+  return name || 'Unknown provider'
+}
+
+function sortProviderEvents(providerEvents: DashboardEvent[]): DashboardEvent[] {
+  return [...providerEvents].sort((left, right) => {
+    const timeCompare = getSortTime(left).localeCompare(getSortTime(right))
+    if (timeCompare !== 0) return timeCompare
+    return left.title.localeCompare(right.title)
+  })
+}
+
+function formatHourLabel(hour: number): string {
+  const ampm = hour >= 12 ? 'PM' : 'AM'
+  let displayHour = hour % 12
+  if (displayHour === 0) {
+    displayHour = 12
+  }
+  return `${displayHour} ${ampm}`
 }
 
 function onDateInput(event: Event) {
@@ -289,11 +501,47 @@ function getSortTime(event: DashboardEvent): string {
   return event.start_time.slice(0, 5)
 }
 
+function parseTimeToMinutes(timeStr?: string): number | null {
+  if (!timeStr) {
+    return null
+  }
+  const [h, m] = timeStr.split(':')
+  const hour = Number.parseInt(h, 10)
+  const minute = Number.parseInt(m || '0', 10)
+  if (Number.isNaN(hour) || Number.isNaN(minute)) {
+    return null
+  }
+  return hour * 60 + minute
+}
+
+function getEventStartMinutes(event: DashboardEvent): number {
+  if (event.is_all_day || !event.start_time) {
+    return GRID_START_MINUTES
+  }
+  return parseTimeToMinutes(event.start_time) ?? GRID_START_MINUTES
+}
+
+function getEventEndMinutes(event: DashboardEvent): number {
+  if (event.is_all_day) {
+    return Math.min(GRID_START_MINUTES + DEFAULT_DURATION_MINUTES, GRID_END_MINUTES)
+  }
+  const start = getEventStartMinutes(event)
+  const end = parseTimeToMinutes(event.end_time)
+  if (end != null && end > start) {
+    return end
+  }
+  return start + DEFAULT_DURATION_MINUTES
+}
+
 function getEventTimeLabel(event: DashboardEvent): string {
   if (event.is_all_day || !event.start_time) {
     return 'All day'
   }
-  return formatEventTime(event.start_time)
+  const startLabel = formatEventTime(event.start_time)
+  if (!event.end_time) {
+    return startLabel
+  }
+  return `${startLabel} – ${formatEventTime(event.end_time)}`
 }
 
 function formatEventType(type: string): string {
@@ -327,6 +575,60 @@ function formatEventTime(timeStr: string): string {
     displayHour -= 12
   }
   return `${displayHour}:${m} ${ampm}`
+}
+
+function displayEventTitle(event: DashboardEvent): string {
+  if (event.is_own_event && event.patient_name) {
+    return event.patient_name.toUpperCase()
+  }
+  if (event.is_own_event && isAppointmentEvent(event)) {
+    return event.title.replace(/\s*\([^)]+\)$/, '').toUpperCase()
+  }
+  return event.title
+}
+
+function providerHeaderStyle(provider: ProviderColumn) {
+  return {
+    backgroundColor: PROVIDER_HEADER_COLORS[provider.colorIndex],
+    color: '#1f2937'
+  }
+}
+
+function providerColumnStyle(provider: ProviderColumn) {
+  return {
+    backgroundColor: PROVIDER_COLUMN_TINTS[provider.colorIndex]
+  }
+}
+
+function scheduleBlockClasses(event: DashboardEvent) {
+  return {
+    'schedule-block--other': !event.is_own_event,
+    'schedule-block--blocked': event.event_type === 'blocked_time',
+    'schedule-block--meeting': event.event_type === 'meeting',
+    'schedule-block--selected': selectedEvent.value?.id === event.id
+  }
+}
+
+function scheduleBlockStyle(event: DashboardEvent, _provider: ProviderColumn) {
+  const start = Math.max(getEventStartMinutes(event), GRID_START_MINUTES)
+  const end = Math.min(getEventEndMinutes(event), GRID_END_MINUTES)
+  const top = ((start - GRID_START_MINUTES) / SLOT_MINUTES) * SLOT_HEIGHT_PX
+  const height = Math.max(((end - start) / SLOT_MINUTES) * SLOT_HEIGHT_PX, SLOT_HEIGHT_PX)
+  const background = event.color || '#dbeafe'
+
+  return {
+    top: `${top}px`,
+    height: `${height}px`,
+    backgroundColor: background
+  }
+}
+
+function selectScheduleEvent(event: DashboardEvent) {
+  selectedEvent.value = event
+}
+
+function clearSelectedEvent() {
+  selectedEvent.value = null
 }
 
 function openNewEventModal() {
@@ -386,7 +688,6 @@ async function saveEvent() {
         alert('Failed to update event')
         return
       }
-
     } else {
       const response = await fetch('/api/events', {
         method: 'POST',
@@ -401,11 +702,10 @@ async function saveEvent() {
         alert('Failed to create event')
         return
       }
-
     }
 
     closeEventModal()
-    await loadEvents()
+    await loadSchedule()
   } catch (error) {
     console.error('Error saving event:', error)
     alert('Failed to save event')
@@ -435,6 +735,9 @@ async function deleteEvent(event: DashboardEvent) {
     }
 
     events.value = events.value.filter((item) => item.id !== event.id)
+    if (selectedEvent.value?.id === event.id) {
+      clearSelectedEvent()
+    }
   } catch (error) {
     console.error('Error deleting event:', error)
     alert('Failed to delete event')
@@ -462,76 +765,113 @@ async function confirmAppointment(event: DashboardEvent) {
       return
     }
 
-    await loadEvents()
+    await loadSchedule()
   } catch (error) {
     console.error('Error confirming appointment:', error)
     alert('Failed to confirm appointment')
   }
 }
 
-async function loadEvents() {
-  isLoading.value = true
-  loadError.value = ''
-
-  const day = formatDate(currentDate.value, 'yyyy-MM-dd')
-
+async function loadProviders() {
   try {
-    const response = await fetch(`/api/events?start_date=${day}&end_date=${day}&include_all_providers=true`, {
+    const response = await fetch('/api/patients/doctors', {
       headers: {
         Authorization: `Bearer ${localStorage.getItem('sessionToken')}`
       }
     })
 
     if (!response.ok) {
-      const data = await response.json().catch(() => ({}))
-      loadError.value = data.error || 'Failed to load events'
       return
     }
 
     const data = await response.json()
-    events.value = data.events || []
+    providers.value = data.doctors || []
   } catch (error) {
-    console.error('Error loading events:', error)
-    loadError.value = 'Failed to load events'
+    console.error('Error loading providers:', error)
+  }
+}
+
+async function loadEvents() {
+  const day = formatDate(currentDate.value, 'yyyy-MM-dd')
+
+  const response = await fetch(`/api/events?start_date=${day}&end_date=${day}&include_all_providers=true`, {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('sessionToken')}`
+    }
+  })
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.error || 'Failed to load events')
+  }
+
+  const data = await response.json()
+  events.value = data.events || []
+}
+
+async function loadSchedule() {
+  isLoading.value = true
+  loadError.value = ''
+
+  try {
+    await Promise.all([loadProviders(), loadEvents()])
+    if (selectedEvent.value) {
+      const stillPresent = events.value.find((event) => event.id === selectedEvent.value?.id)
+      selectedEvent.value = stillPresent || null
+    }
+  } catch (error) {
+    console.error('Error loading schedule:', error)
+    loadError.value = error instanceof Error ? error.message : 'Failed to load events'
   } finally {
     isLoading.value = false
   }
 }
 
 watch(currentDate, () => {
-  loadEvents()
+  loadSchedule()
 })
 
 onMounted(() => {
-  loadEvents()
+  loadSchedule()
 })
 </script>
 
 <style scoped>
 .provider-dashboard {
-  background: #f5f5f5;
+  background: #eef1f4;
   min-height: 100vh;
   padding-bottom: 2rem;
 }
 
 .dashboard-header {
   background: white;
-  margin-bottom: 1.5rem;
-  padding: 1.25rem 1.5rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  margin-bottom: 1rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .header-main h1 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: 1.45rem;
+  color: #1a3a5c;
 }
 
 .header-main p {
-  margin: 0.35rem 0 1rem 0;
+  margin: 0.3rem 0 0.85rem 0;
   color: #4b5563;
+  font-size: 0.92rem;
 }
 
-.date-navigation {
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.date-navigation,
+.toolbar-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -539,39 +879,74 @@ onMounted(() => {
 }
 
 .nav-btn {
-  padding: 0.5rem 0.9rem;
-  border: 1px solid #d1d5db;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid #c5ced8;
   background: white;
-  border-radius: 4px;
+  border-radius: 3px;
   cursor: pointer;
+  font-weight: 600;
+  color: #1f2937;
 }
 
 .nav-btn:hover {
   background: #f3f4f6;
 }
 
+.today-btn {
+  background: #1a3a5c;
+  color: white;
+  border-color: #1a3a5c;
+}
+
+.today-btn:hover {
+  background: #152e49;
+}
+
+.arrow-btn {
+  color: #2563eb;
+  font-size: 1.05rem;
+  min-width: 2.25rem;
+}
+
+.current-date-label {
+  font-weight: 700;
+  color: #111827;
+  min-width: 10rem;
+  text-align: center;
+}
+
 .date-input {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid #c5ced8;
+  border-radius: 3px;
+}
+
+.patient-search-input {
+  min-width: 14rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid #c5ced8;
+  border-radius: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .schedule-container {
-  margin: 0 1.5rem;
+  margin: 0 1rem;
   background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
   overflow: hidden;
-}
-
-.schedule-header {
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid #e5e7eb;
-}
-
-.schedule-header h2 {
-  margin: 0;
-  font-size: 1.2rem;
 }
 
 .status-message {
@@ -588,89 +963,200 @@ onMounted(() => {
   color: #6b7280;
 }
 
-.provider-columns {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1rem;
-  padding: 1rem 1.5rem 1.5rem;
+.schedule-board {
+  display: flex;
+  flex-direction: column;
 }
 
-.provider-column {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  background: #fafafa;
-  overflow: hidden;
+.board-scroll {
+  overflow-x: auto;
+  overflow-y: auto;
+  max-height: calc(100vh - 220px);
+}
+
+.board-header-row,
+.board-body {
+  display: grid;
+  grid-template-columns: 64px repeat(var(--provider-count, 1), minmax(170px, 1fr)) 64px;
+  min-width: max-content;
+  width: 100%;
+}
+
+.board-header-row {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  border-bottom: 1px solid #9ca3af;
+}
+
+.time-axis-spacer {
+  background: #f8fafc;
+  border-right: 1px solid #d1d5db;
+  border-left: 1px solid #d1d5db;
+  min-width: 64px;
 }
 
 .provider-column-header {
-  padding: 0.75rem 0.9rem;
-  background: #e0ecff;
-  color: #1e3a8a;
+  padding: 0.55rem 0.65rem;
   font-weight: 700;
-  border-bottom: 1px solid #dbeafe;
+  font-size: 0.92rem;
+  text-align: center;
+  border-right: 1px solid #9ca3af;
+  white-space: nowrap;
 }
 
-.provider-events {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.75rem;
+.board-body {
+  position: relative;
 }
 
-.schedule-item {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  background: white;
-  padding: 0.75rem;
+.time-axis {
+  background: #f8fafc;
+  border-right: 1px solid #d1d5db;
+  border-left: 1px solid #d1d5db;
 }
 
-.schedule-item--other {
-  background: #f9fafb;
-  border-style: dashed;
-}
-
-.schedule-item--other .event-title {
+.time-slot-label {
+  box-sizing: border-box;
+  padding: 0 0.35rem;
+  font-size: 0.72rem;
   color: #4b5563;
-}
-
-.event-topline {
   display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  border-top: 1px solid transparent;
+}
+
+.time-slot-label--hour {
+  font-weight: 700;
+  color: #111827;
+  border-top-color: #9ca3af;
+}
+
+.minute-marker {
+  color: #9ca3af;
+  font-size: 0.65rem;
+}
+
+.provider-column {
+  position: relative;
+  border-right: 1px solid #9ca3af;
+  min-width: 170px;
+}
+
+.column-grid-lines {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.grid-line {
+  box-sizing: border-box;
+  border-top: 1px solid #e5e7eb;
+}
+
+.grid-line--hour {
+  border-top-color: #9ca3af;
+}
+
+.schedule-block {
+  position: absolute;
+  left: 3px;
+  right: 3px;
+  z-index: 2;
+  border: 1px solid rgba(31, 41, 55, 0.25);
+  border-radius: 2px;
+  padding: 0.2rem 0.35rem;
+  text-align: left;
+  overflow: hidden;
+  cursor: pointer;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.06);
+}
+
+.schedule-block:hover,
+.schedule-block--selected {
+  outline: 2px solid #1d4ed8;
+  z-index: 3;
+}
+
+.schedule-block--other {
+  border-style: dashed;
+  opacity: 0.95;
+}
+
+.schedule-block--blocked {
+  border: 2px solid #dc2626;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(254, 226, 226, 0.55),
+    rgba(254, 226, 226, 0.55) 6px,
+    rgba(254, 242, 242, 0.85) 6px,
+    rgba(254, 242, 242, 0.85) 12px
+  );
+}
+
+.schedule-block--meeting {
+  border-color: #7c3aed;
+}
+
+.block-title {
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.15;
+  color: #111827;
+  word-break: break-word;
+}
+
+.block-meta,
+.block-description {
+  font-size: 0.68rem;
+  line-height: 1.2;
+  color: #1f2937;
+  margin-top: 0.1rem;
+}
+
+.block-description {
+  color: #374151;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.selection-panel {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-top: 1px solid #d1d5db;
+  background: #f8fafc;
 }
 
-.event-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-.event-title {
-  font-weight: 600;
+.selection-title {
+  font-weight: 700;
   color: #111827;
 }
 
-.event-meta {
+.selection-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
+  margin-top: 0.25rem;
+  color: #4b5563;
   font-size: 0.9rem;
+}
+
+.selection-description {
+  margin: 0.4rem 0 0 0;
   color: #374151;
 }
 
-.event-description {
-  margin: 0.5rem 0 0 0;
-  color: #4b5563;
-}
-
-.actions-column {
+.selection-actions {
   display: flex;
-  align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 0.65rem;
+  align-items: center;
 }
 
 .action-btn,
@@ -827,13 +1313,17 @@ onMounted(() => {
 }
 
 @media (max-width: 900px) {
-  .provider-columns {
-    grid-template-columns: 1fr;
-    padding: 0.75rem 1rem 1rem;
+  .toolbar {
+    align-items: stretch;
   }
 
-  .actions-column {
-    justify-content: flex-start;
+  .patient-search-input {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .board-scroll {
+    max-height: calc(100vh - 280px);
   }
 }
 </style>

--- a/src/views/ProviderDashboard.vue
+++ b/src/views/ProviderDashboard.vue
@@ -49,7 +49,7 @@
               class="provider-column-header"
               :style="providerHeaderStyle(provider)"
             >
-              {{ provider.label }} ({{ provider.events.length }})
+              {{ provider.label }} ({{ provider.layoutEvents.length }})
             </div>
             <div class="time-axis-spacer" aria-hidden="true"></div>
           </div>
@@ -85,28 +85,28 @@
               </div>
 
               <button
-                v-for="event in provider.events"
-                :key="event.id"
+                v-for="item in provider.layoutEvents"
+                :key="item.event.id"
                 type="button"
                 class="schedule-block"
-                :class="scheduleBlockClasses(event)"
-                :style="scheduleBlockStyle(event, provider)"
-                @click="selectScheduleEvent(event)"
+                :class="scheduleBlockClasses(item.event)"
+                :style="scheduleBlockStyle(item)"
+                @click="selectScheduleEvent(item.event)"
               >
-                <div class="block-title">{{ displayEventTitle(event) }}</div>
-                <div class="block-meta">{{ getEventTimeLabel(event) }}</div>
-                <div class="block-meta">{{ formatEventType(event.event_type) }}</div>
+                <div class="block-title">{{ displayEventTitle(item.event) }}</div>
+                <div class="block-meta">{{ getEventTimeLabel(item.event) }}</div>
+                <div class="block-meta">{{ formatEventType(item.event.event_type) }}</div>
                 <div
-                  v-if="event.is_own_event && event.description"
+                  v-if="item.event.is_own_event && item.event.description"
                   class="block-description"
                 >
-                  {{ event.description }}
+                  {{ item.event.description }}
                 </div>
                 <div
-                  v-if="isAppointmentEvent(event) && getAppointmentStatus(event)"
+                  v-if="isAppointmentEvent(item.event) && getAppointmentStatus(item.event)"
                   class="block-meta"
                 >
-                  {{ getAppointmentStatus(event) }}
+                  {{ getAppointmentStatus(item.event) }}
                 </div>
               </button>
             </div>
@@ -282,12 +282,20 @@ interface ClinicProvider {
   last_name?: string
 }
 
+interface LaidOutEvent {
+  event: DashboardEvent
+  lane: number
+  laneCount: number
+  visibleStart: number
+  visibleEnd: number
+}
+
 interface ProviderColumn {
   key: string
   doctorId: string
   label: string
   colorIndex: number
-  events: DashboardEvent[]
+  layoutEvents: LaidOutEvent[]
 }
 
 interface EventForm {
@@ -387,16 +395,7 @@ const dayEvents = computed(() => {
 
   return events.value
     .filter((event) => event.event_date === dateStr)
-    .filter((event) => {
-      if (!query) {
-        return true
-      }
-      if (!event.is_own_event) {
-        return false
-      }
-      const haystack = `${event.patient_name || ''} ${event.title || ''}`.toLowerCase()
-      return haystack.includes(query)
-    })
+    .filter((event) => matchesPatientSearch(event, query))
     .sort((left, right) => getSortTime(left).localeCompare(getSortTime(right)))
 })
 
@@ -422,7 +421,7 @@ const providerColumns = computed<ProviderColumn[]>(() => {
       doctorId,
       label,
       colorIndex: index % PROVIDER_HEADER_COLORS.length,
-      events: sortProviderEvents(eventsByDoctor.get(doctorId) || [])
+      layoutEvents: layoutProviderEvents(eventsByDoctor.get(doctorId) || [])
     })
   })
 
@@ -436,11 +435,21 @@ const providerColumns = computed<ProviderColumn[]>(() => {
       doctorId,
       label,
       colorIndex: columns.length % PROVIDER_HEADER_COLORS.length,
-      events: sortProviderEvents(providerEvents)
+      layoutEvents: layoutProviderEvents(providerEvents)
     })
   }
 
   return columns.sort((left, right) => left.label.localeCompare(right.label))
+})
+
+const visibleEventIds = computed(() => {
+  const ids = new Set<string>()
+  for (const column of providerColumns.value) {
+    for (const item of column.layoutEvents) {
+      ids.add(item.event.id)
+    }
+  }
+  return ids
 })
 
 const boardGridStyle = computed(() => ({
@@ -457,12 +466,16 @@ function formatProviderName(provider: ClinicProvider): string {
   return name || 'Unknown provider'
 }
 
-function sortProviderEvents(providerEvents: DashboardEvent[]): DashboardEvent[] {
-  return [...providerEvents].sort((left, right) => {
-    const timeCompare = getSortTime(left).localeCompare(getSortTime(right))
-    if (timeCompare !== 0) return timeCompare
-    return left.title.localeCompare(right.title)
-  })
+function matchesPatientSearch(event: DashboardEvent, query: string): boolean {
+  if (!query) {
+    return true
+  }
+  // Keep other providers' redacted availability visible on the clinic-wide board.
+  if (!event.is_own_event) {
+    return true
+  }
+  const haystack = `${event.patient_name || ''} ${event.title || ''}`.toLowerCase()
+  return haystack.includes(query)
 }
 
 function formatHourLabel(hour: number): string {
@@ -495,7 +508,7 @@ function goToToday() {
 }
 
 function getSortTime(event: DashboardEvent): string {
-  if (!event.start_time) {
+  if (event.is_all_day || !event.start_time) {
     return '00:00'
   }
   return event.start_time.slice(0, 5)
@@ -515,7 +528,10 @@ function parseTimeToMinutes(timeStr?: string): number | null {
 }
 
 function getEventStartMinutes(event: DashboardEvent): number {
-  if (event.is_all_day || !event.start_time) {
+  if (event.is_all_day) {
+    return GRID_START_MINUTES
+  }
+  if (!event.start_time) {
     return GRID_START_MINUTES
   }
   return parseTimeToMinutes(event.start_time) ?? GRID_START_MINUTES
@@ -523,7 +539,7 @@ function getEventStartMinutes(event: DashboardEvent): number {
 
 function getEventEndMinutes(event: DashboardEvent): number {
   if (event.is_all_day) {
-    return Math.min(GRID_START_MINUTES + DEFAULT_DURATION_MINUTES, GRID_END_MINUTES)
+    return GRID_END_MINUTES
   }
   const start = getEventStartMinutes(event)
   const end = parseTimeToMinutes(event.end_time)
@@ -531,6 +547,117 @@ function getEventEndMinutes(event: DashboardEvent): number {
     return end
   }
   return start + DEFAULT_DURATION_MINUTES
+}
+
+/** Clamp to the visible grid window; null if the event does not intersect it. */
+function getVisibleRange(event: DashboardEvent): { start: number; end: number } | null {
+  const rawStart = getEventStartMinutes(event)
+  const rawEnd = getEventEndMinutes(event)
+  if (rawEnd <= GRID_START_MINUTES || rawStart >= GRID_END_MINUTES) {
+    return null
+  }
+  const start = Math.max(rawStart, GRID_START_MINUTES)
+  const end = Math.min(rawEnd, GRID_END_MINUTES)
+  if (end <= start) {
+    return null
+  }
+  return { start, end }
+}
+
+function eventsOverlap(
+  left: { start: number; end: number },
+  right: { start: number; end: number }
+): boolean {
+  return left.start < right.end && right.start < left.end
+}
+
+function layoutProviderEvents(providerEvents: DashboardEvent[]): LaidOutEvent[] {
+  const visible = providerEvents
+    .map((event) => {
+      const range = getVisibleRange(event)
+      if (!range) {
+        return null
+      }
+      return {
+        event,
+        visibleStart: range.start,
+        visibleEnd: range.end
+      }
+    })
+    .filter((item): item is { event: DashboardEvent; visibleStart: number; visibleEnd: number } => item != null)
+    .sort((left, right) => {
+      if (left.visibleStart !== right.visibleStart) {
+        return left.visibleStart - right.visibleStart
+      }
+      if (left.visibleEnd !== right.visibleEnd) {
+        return left.visibleEnd - right.visibleEnd
+      }
+      return left.event.title.localeCompare(right.event.title)
+    })
+
+  if (visible.length === 0) {
+    return []
+  }
+
+  const laneEnds: number[] = []
+  const provisional: Array<{
+    event: DashboardEvent
+    visibleStart: number
+    visibleEnd: number
+    lane: number
+  }> = []
+
+  for (const item of visible) {
+    let lane = laneEnds.findIndex((end) => end <= item.visibleStart)
+    if (lane === -1) {
+      lane = laneEnds.length
+      laneEnds.push(item.visibleEnd)
+    } else {
+      laneEnds[lane] = item.visibleEnd
+    }
+    provisional.push({ ...item, lane })
+  }
+
+  // Within each overlapping cluster, laneCount is the max lane index + 1.
+  return provisional.map((item) => {
+    const cluster = new Set<string>([item.event.id])
+    let changed = true
+    while (changed) {
+      changed = false
+      for (const candidate of provisional) {
+        if (cluster.has(candidate.event.id)) {
+          continue
+        }
+        const overlapsCluster = provisional.some(
+          (member) =>
+            cluster.has(member.event.id)
+            && eventsOverlap(
+              { start: member.visibleStart, end: member.visibleEnd },
+              { start: candidate.visibleStart, end: candidate.visibleEnd }
+            )
+        )
+        if (overlapsCluster) {
+          cluster.add(candidate.event.id)
+          changed = true
+        }
+      }
+    }
+
+    let maxLane = 0
+    for (const member of provisional) {
+      if (cluster.has(member.event.id)) {
+        maxLane = Math.max(maxLane, member.lane)
+      }
+    }
+
+    return {
+      event: item.event,
+      lane: item.lane,
+      laneCount: maxLane + 1,
+      visibleStart: item.visibleStart,
+      visibleEnd: item.visibleEnd
+    }
+  })
 }
 
 function getEventTimeLabel(event: DashboardEvent): string {
@@ -605,21 +732,30 @@ function scheduleBlockClasses(event: DashboardEvent) {
     'schedule-block--other': !event.is_own_event,
     'schedule-block--blocked': event.event_type === 'blocked_time',
     'schedule-block--meeting': event.event_type === 'meeting',
+    'schedule-block--all-day': event.is_all_day,
     'schedule-block--selected': selectedEvent.value?.id === event.id
   }
 }
 
-function scheduleBlockStyle(event: DashboardEvent, _provider: ProviderColumn) {
-  const start = Math.max(getEventStartMinutes(event), GRID_START_MINUTES)
-  const end = Math.min(getEventEndMinutes(event), GRID_END_MINUTES)
-  const top = ((start - GRID_START_MINUTES) / SLOT_MINUTES) * SLOT_HEIGHT_PX
-  const height = Math.max(((end - start) / SLOT_MINUTES) * SLOT_HEIGHT_PX, SLOT_HEIGHT_PX)
-  const background = event.color || '#dbeafe'
+function scheduleBlockStyle(item: LaidOutEvent) {
+  const top = ((item.visibleStart - GRID_START_MINUTES) / SLOT_MINUTES) * SLOT_HEIGHT_PX
+  const height = Math.max(
+    ((item.visibleEnd - item.visibleStart) / SLOT_MINUTES) * SLOT_HEIGHT_PX,
+    SLOT_HEIGHT_PX
+  )
+  const laneCount = Math.max(item.laneCount, 1)
+  const widthPercent = 100 / laneCount
+  const leftPercent = item.lane * widthPercent
+  const background = item.event.color || '#dbeafe'
 
   return {
     top: `${top}px`,
     height: `${height}px`,
-    backgroundColor: background
+    left: `calc(${leftPercent}% + 2px)`,
+    width: `calc(${widthPercent}% - 4px)`,
+    right: 'auto',
+    backgroundColor: background,
+    zIndex: item.event.is_all_day ? 1 : 2 + item.lane
   }
 }
 
@@ -815,9 +951,8 @@ async function loadSchedule() {
 
   try {
     await Promise.all([loadProviders(), loadEvents()])
-    if (selectedEvent.value) {
-      const stillPresent = events.value.find((event) => event.id === selectedEvent.value?.id)
-      selectedEvent.value = stillPresent || null
+    if (selectedEvent.value && !visibleEventIds.value.has(selectedEvent.value.id)) {
+      clearSelectedEvent()
     }
   } catch (error) {
     console.error('Error loading schedule:', error)
@@ -829,6 +964,12 @@ async function loadSchedule() {
 
 watch(currentDate, () => {
   loadSchedule()
+})
+
+watch(visibleEventIds, (ids) => {
+  if (selectedEvent.value && !ids.has(selectedEvent.value.id)) {
+    clearSelectedEvent()
+  }
 })
 
 onMounted(() => {
@@ -1060,8 +1201,7 @@ onMounted(() => {
 
 .schedule-block {
   position: absolute;
-  left: 3px;
-  right: 3px;
+  box-sizing: border-box;
   z-index: 2;
   border: 1px solid rgba(31, 41, 55, 0.25);
   border-radius: 2px;
@@ -1075,7 +1215,7 @@ onMounted(() => {
 .schedule-block:hover,
 .schedule-block--selected {
   outline: 2px solid #1d4ed8;
-  z-index: 3;
+  z-index: 8 !important;
 }
 
 .schedule-block--other {
@@ -1096,6 +1236,12 @@ onMounted(() => {
 
 .schedule-block--meeting {
   border-color: #7c3aed;
+}
+
+.schedule-block--all-day {
+  border-style: solid;
+  border-color: #4b5563;
+  opacity: 0.88;
 }
 
 .block-title {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Upgrades the provider Scheduling Assistant from a stacked multi-provider card list into a clinic-style day time grid that matches the target scheduling board layout.

## Changes
- Rebuilds `ProviderDashboard` as a **Scheduling Assistant** board with Today / date arrows / formatted date chrome and a client-side patient search filter
- Loads all clinic providers via `GET /api/patients/doctors` so **empty columns still render**
- Renders a shared **15-minute** time axis (7 AM–8 PM) with absolutely positioned appointment/event blocks (default 30-minute height when `end_time` is missing)
- Adds colored provider headers with counts and tinted columns; distinct blocked-time / meeting / other-provider block styles
- Moves Confirm / Edit / Delete into a selection panel so blocks stay dense, while keeping existing PHI redaction rules

## Testing
- `npm test -- src/views/ProviderDashboard.spec.ts`
- `npx vue-tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cd14074-6a4d-4cb4-88b1-17a2eda2e92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cd14074-6a4d-4cb4-88b1-17a2eda2e92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

