### PR TITLE
Add provider patient chart (allergies, meds, problems, document visibility)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -38,6 +38,7 @@ from api.routes.appointments import appointments_bp
 from api.routes.feature_requests import feature_requests_bp
 from api.routes.messages import messages_bp
 from api.routes.admin import admin_bp
+from api.routes.chart import chart_bp
 
 # Create Flask app
 app = Flask(__name__)
@@ -96,6 +97,7 @@ app.register_blueprint(appointments_bp)
 app.register_blueprint(feature_requests_bp)
 app.register_blueprint(messages_bp)
 app.register_blueprint(admin_bp)
+app.register_blueprint(chart_bp)
 
 # Error handlers
 @app.errorhandler(404)

--- a/api/routes/chart.py
+++ b/api/routes/chart.py
@@ -1,0 +1,669 @@
+"""
+Provider-only patient chart routes
+Summary + CRUD for allergies, medications, and problems
+"""
+
+from flask import Blueprint, request, jsonify, current_app
+from datetime import datetime, date
+from api.db.connection import execute_query
+from api.middleware.auth import authenticate
+from api.utils.audit_log import log_data_access
+
+chart_bp = Blueprint('chart', __name__, url_prefix='/api/chart')
+
+INSUFFICIENT_PERMISSIONS_ERROR = 'Insufficient permissions'
+PATIENT_NOT_FOUND_ERROR = 'Patient not found'
+FAILED_RETRIEVE_SUMMARY_ERROR = 'Failed to retrieve chart summary'
+FAILED_RETRIEVE_ALLERGIES_ERROR = 'Failed to retrieve allergies'
+FAILED_CREATE_ALLERGY_ERROR = 'Failed to create allergy'
+FAILED_UPDATE_ALLERGY_ERROR = 'Failed to update allergy'
+FAILED_DELETE_ALLERGY_ERROR = 'Failed to delete allergy'
+FAILED_RETRIEVE_MEDICATIONS_ERROR = 'Failed to retrieve medications'
+FAILED_CREATE_MEDICATION_ERROR = 'Failed to create medication'
+FAILED_UPDATE_MEDICATION_ERROR = 'Failed to update medication'
+FAILED_DELETE_MEDICATION_ERROR = 'Failed to delete medication'
+FAILED_RETRIEVE_PROBLEMS_ERROR = 'Failed to retrieve problems'
+FAILED_CREATE_PROBLEM_ERROR = 'Failed to create problem'
+FAILED_UPDATE_PROBLEM_ERROR = 'Failed to update problem'
+FAILED_DELETE_PROBLEM_ERROR = 'Failed to delete problem'
+
+ALLERGY_SEVERITIES = {'mild', 'moderate', 'severe', 'unknown'}
+ALLERGY_STATUSES = {'active', 'inactive'}
+MEDICATION_STATUSES = {'active', 'discontinued', 'completed'}
+PROBLEM_STATUSES = {'active', 'resolved', 'inactive'}
+
+ALLERGY_SELECT = """
+    SELECT a.id, a.patient_id, a.allergen, a.reaction, a.severity, a.status,
+           a.notes, a.recorded_at, a.created_by_doctor_id,
+           a.created_at, a.updated_at,
+           d.first_name || ' ' || d.last_name AS created_by_name
+    FROM allergies a
+    LEFT JOIN doctors d ON d.id = a.created_by_doctor_id
+"""
+
+MEDICATION_SELECT = """
+    SELECT m.id, m.patient_id, m.name, m.dosage, m.frequency, m.route, m.status,
+           m.start_date, m.end_date, m.notes, m.prescribed_by_doctor_id,
+           m.created_at, m.updated_at,
+           d.first_name || ' ' || d.last_name AS prescribed_by_name
+    FROM medications m
+    LEFT JOIN doctors d ON d.id = m.prescribed_by_doctor_id
+"""
+
+PROBLEM_SELECT = """
+    SELECT p.id, p.patient_id, p.name, p.status, p.onset_date, p.resolved_date,
+           p.notes, p.created_by_doctor_id, p.created_at, p.updated_at,
+           d.first_name || ' ' || d.last_name AS created_by_name
+    FROM problems p
+    LEFT JOIN doctors d ON d.id = p.created_by_doctor_id
+"""
+
+
+def serialize_row(row):
+    if not row:
+        return None
+    result = dict(row)
+    for key, value in result.items():
+        if isinstance(value, (datetime, date)):
+            result[key] = value.isoformat()
+    return result
+
+
+def _get_doctor_id(user_id):
+    doctor_row = execute_query(
+        'SELECT id FROM doctors WHERE user_id = %s',
+        (user_id,),
+        fetch_one=True,
+    )
+    return doctor_row['id'] if doctor_row else None
+
+
+def _require_doctor():
+    user = request.user
+    if user.get('role') != 'doctor':
+        return None, (jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403)
+    doctor_id = _get_doctor_id(user['id'])
+    if not doctor_id:
+        return None, (jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403)
+    return doctor_id, None
+
+
+def _patient_exists(patient_id):
+    row = execute_query(
+        'SELECT id FROM patients WHERE id = %s',
+        (patient_id,),
+        fetch_one=True,
+    )
+    return bool(row)
+
+
+def _parse_optional_date(value, field_name):
+    if value is None or value == '':
+        return None, None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value, None
+    try:
+        return date.fromisoformat(str(value)[:10]), None
+    except ValueError:
+        return None, (jsonify({'error': f'{field_name} must be a valid date (YYYY-MM-DD)'}), 400)
+
+
+def _fetch_allergy(allergy_id, patient_id=None):
+    query = f"{ALLERGY_SELECT} WHERE a.id = %s"
+    params = [allergy_id]
+    if patient_id:
+        query += ' AND a.patient_id = %s'
+        params.append(patient_id)
+    return execute_query(query, tuple(params), fetch_one=True)
+
+
+def _fetch_medication(medication_id, patient_id=None):
+    query = f"{MEDICATION_SELECT} WHERE m.id = %s"
+    params = [medication_id]
+    if patient_id:
+        query += ' AND m.patient_id = %s'
+        params.append(patient_id)
+    return execute_query(query, tuple(params), fetch_one=True)
+
+
+def _fetch_problem(problem_id, patient_id=None):
+    query = f"{PROBLEM_SELECT} WHERE p.id = %s"
+    params = [problem_id]
+    if patient_id:
+        query += ' AND p.patient_id = %s'
+        params.append(patient_id)
+    return execute_query(query, tuple(params), fetch_one=True)
+
+
+@chart_bp.route('/<patient_id>/summary', methods=['GET'])
+@authenticate
+def get_summary(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        allergies = execute_query(
+            f"{ALLERGY_SELECT} WHERE a.patient_id = %s AND a.status = 'active' ORDER BY a.allergen",
+            (patient_id,),
+            fetch_all=True,
+        ) or []
+        medications = execute_query(
+            f"{MEDICATION_SELECT} WHERE m.patient_id = %s AND m.status = 'active' ORDER BY m.name",
+            (patient_id,),
+            fetch_all=True,
+        ) or []
+        problems = execute_query(
+            f"{PROBLEM_SELECT} WHERE p.patient_id = %s AND p.status = 'active' ORDER BY p.name",
+            (patient_id,),
+            fetch_all=True,
+        ) or []
+
+        user = request.user
+        log_data_access(user['id'], 'chart_summary', patient_id, 'VIEW', request)
+
+        return jsonify({
+            'summary': {
+                'allergies': [serialize_row(row) for row in allergies],
+                'medications': [serialize_row(row) for row in medications],
+                'problems': [serialize_row(row) for row in problems],
+                'allergy_count': len(allergies),
+                'medication_count': len(medications),
+                'problem_count': len(problems),
+            }
+        }), 200
+    except Exception:
+        current_app.logger.exception('Chart summary retrieval error')
+        return jsonify({'error': FAILED_RETRIEVE_SUMMARY_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/allergies', methods=['GET'])
+@authenticate
+def list_allergies(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        rows = execute_query(
+            f"{ALLERGY_SELECT} WHERE a.patient_id = %s ORDER BY a.status, a.allergen",
+            (patient_id,),
+            fetch_all=True,
+        ) or []
+        log_data_access(request.user['id'], 'allergies', patient_id, 'VIEW', request)
+        return jsonify({'allergies': [serialize_row(row) for row in rows]}), 200
+    except Exception:
+        current_app.logger.exception('Allergies list error')
+        return jsonify({'error': FAILED_RETRIEVE_ALLERGIES_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/allergies', methods=['POST'])
+@authenticate
+def create_allergy(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        data = request.get_json(silent=True) or {}
+        allergen = (data.get('allergen') or '').strip()
+        if not allergen:
+            return jsonify({'error': 'allergen is required'}), 400
+
+        severity = (data.get('severity') or 'unknown').strip().lower()
+        if severity not in ALLERGY_SEVERITIES:
+            return jsonify({'error': 'severity must be mild, moderate, severe, or unknown'}), 400
+
+        status = (data.get('status') or 'active').strip().lower()
+        if status not in ALLERGY_STATUSES:
+            return jsonify({'error': 'status must be active or inactive'}), 400
+
+        insert_query = """
+            INSERT INTO allergies (
+                patient_id, allergen, reaction, severity, status, notes, created_by_doctor_id
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+        """
+        created = execute_query(
+            insert_query,
+            (
+                patient_id,
+                allergen,
+                data.get('reaction'),
+                severity,
+                status,
+                data.get('notes'),
+                doctor_id,
+            ),
+            fetch_one=True,
+        )
+        allergy = _fetch_allergy(created['id'], patient_id)
+        log_data_access(request.user['id'], 'allergies', created['id'], 'CREATE', request)
+        return jsonify({'allergy': serialize_row(allergy)}), 201
+    except Exception:
+        current_app.logger.exception('Allergy creation error')
+        return jsonify({'error': FAILED_CREATE_ALLERGY_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/allergies/<allergy_id>', methods=['PUT'])
+@authenticate
+def update_allergy(patient_id, allergy_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        existing = _fetch_allergy(allergy_id, patient_id)
+        if not existing:
+            return jsonify({'error': 'Allergy not found'}), 404
+
+        data = request.get_json(silent=True) or {}
+        allergen = data.get('allergen', existing['allergen'])
+        allergen = (allergen or '').strip()
+        if not allergen:
+            return jsonify({'error': 'allergen cannot be empty'}), 400
+
+        severity = (data.get('severity', existing['severity']) or 'unknown').strip().lower()
+        if severity not in ALLERGY_SEVERITIES:
+            return jsonify({'error': 'severity must be mild, moderate, severe, or unknown'}), 400
+
+        status = (data.get('status', existing['status']) or 'active').strip().lower()
+        if status not in ALLERGY_STATUSES:
+            return jsonify({'error': 'status must be active or inactive'}), 400
+
+        reaction = data['reaction'] if 'reaction' in data else existing.get('reaction')
+        notes = data['notes'] if 'notes' in data else existing.get('notes')
+
+        updated = execute_query(
+            """
+            UPDATE allergies
+            SET allergen = %s, reaction = %s, severity = %s, status = %s,
+                notes = %s, updated_at = NOW()
+            WHERE id = %s AND patient_id = %s
+            RETURNING id
+            """,
+            (allergen, reaction, severity, status, notes, allergy_id, patient_id),
+            fetch_one=True,
+        )
+        if not updated:
+            return jsonify({'error': 'Allergy not found'}), 404
+
+        allergy = _fetch_allergy(allergy_id, patient_id)
+        log_data_access(request.user['id'], 'allergies', allergy_id, 'UPDATE', request)
+        return jsonify({'allergy': serialize_row(allergy)}), 200
+    except Exception:
+        current_app.logger.exception('Allergy update error')
+        return jsonify({'error': FAILED_UPDATE_ALLERGY_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/allergies/<allergy_id>', methods=['DELETE'])
+@authenticate
+def delete_allergy(patient_id, allergy_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        existing = _fetch_allergy(allergy_id, patient_id)
+        if not existing:
+            return jsonify({'error': 'Allergy not found'}), 404
+
+        deleted = execute_query(
+            'DELETE FROM allergies WHERE id = %s AND patient_id = %s RETURNING id',
+            (allergy_id, patient_id),
+            fetch_one=True,
+        )
+        if not deleted:
+            return jsonify({'error': 'Allergy not found'}), 404
+
+        log_data_access(request.user['id'], 'allergies', allergy_id, 'DELETE', request)
+        return jsonify({'message': 'Allergy deleted'}), 200
+    except Exception:
+        current_app.logger.exception('Allergy deletion error')
+        return jsonify({'error': FAILED_DELETE_ALLERGY_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/medications', methods=['GET'])
+@authenticate
+def list_medications(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        rows = execute_query(
+            f"{MEDICATION_SELECT} WHERE m.patient_id = %s ORDER BY m.status, m.name",
+            (patient_id,),
+            fetch_all=True,
+        ) or []
+        log_data_access(request.user['id'], 'medications', patient_id, 'VIEW', request)
+        return jsonify({'medications': [serialize_row(row) for row in rows]}), 200
+    except Exception:
+        current_app.logger.exception('Medications list error')
+        return jsonify({'error': FAILED_RETRIEVE_MEDICATIONS_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/medications', methods=['POST'])
+@authenticate
+def create_medication(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        data = request.get_json(silent=True) or {}
+        name = (data.get('name') or '').strip()
+        if not name:
+            return jsonify({'error': 'name is required'}), 400
+
+        status = (data.get('status') or 'active').strip().lower()
+        if status not in MEDICATION_STATUSES:
+            return jsonify({'error': 'status must be active, discontinued, or completed'}), 400
+
+        start_date, start_error = _parse_optional_date(data.get('start_date'), 'start_date')
+        if start_error:
+            return start_error
+        end_date, end_error = _parse_optional_date(data.get('end_date'), 'end_date')
+        if end_error:
+            return end_error
+
+        created = execute_query(
+            """
+            INSERT INTO medications (
+                patient_id, name, dosage, frequency, route, status,
+                start_date, end_date, notes, prescribed_by_doctor_id
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                patient_id,
+                name,
+                data.get('dosage'),
+                data.get('frequency'),
+                data.get('route'),
+                status,
+                start_date,
+                end_date,
+                data.get('notes'),
+                doctor_id,
+            ),
+            fetch_one=True,
+        )
+        medication = _fetch_medication(created['id'], patient_id)
+        log_data_access(request.user['id'], 'medications', created['id'], 'CREATE', request)
+        return jsonify({'medication': serialize_row(medication)}), 201
+    except Exception:
+        current_app.logger.exception('Medication creation error')
+        return jsonify({'error': FAILED_CREATE_MEDICATION_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/medications/<medication_id>', methods=['PUT'])
+@authenticate
+def update_medication(patient_id, medication_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        existing = _fetch_medication(medication_id, patient_id)
+        if not existing:
+            return jsonify({'error': 'Medication not found'}), 404
+
+        data = request.get_json(silent=True) or {}
+        name = data.get('name', existing['name'])
+        name = (name or '').strip()
+        if not name:
+            return jsonify({'error': 'name cannot be empty'}), 400
+
+        status = (data.get('status', existing['status']) or 'active').strip().lower()
+        if status not in MEDICATION_STATUSES:
+            return jsonify({'error': 'status must be active, discontinued, or completed'}), 400
+
+        start_date, start_error = _parse_optional_date(
+            data['start_date'] if 'start_date' in data else existing.get('start_date'),
+            'start_date',
+        )
+        if start_error:
+            return start_error
+        end_date, end_error = _parse_optional_date(
+            data['end_date'] if 'end_date' in data else existing.get('end_date'),
+            'end_date',
+        )
+        if end_error:
+            return end_error
+
+        dosage = data['dosage'] if 'dosage' in data else existing.get('dosage')
+        frequency = data['frequency'] if 'frequency' in data else existing.get('frequency')
+        route = data['route'] if 'route' in data else existing.get('route')
+        notes = data['notes'] if 'notes' in data else existing.get('notes')
+
+        updated = execute_query(
+            """
+            UPDATE medications
+            SET name = %s, dosage = %s, frequency = %s, route = %s, status = %s,
+                start_date = %s, end_date = %s, notes = %s, updated_at = NOW()
+            WHERE id = %s AND patient_id = %s
+            RETURNING id
+            """,
+            (
+                name, dosage, frequency, route, status,
+                start_date, end_date, notes, medication_id, patient_id,
+            ),
+            fetch_one=True,
+        )
+        if not updated:
+            return jsonify({'error': 'Medication not found'}), 404
+
+        medication = _fetch_medication(medication_id, patient_id)
+        log_data_access(request.user['id'], 'medications', medication_id, 'UPDATE', request)
+        return jsonify({'medication': serialize_row(medication)}), 200
+    except Exception:
+        current_app.logger.exception('Medication update error')
+        return jsonify({'error': FAILED_UPDATE_MEDICATION_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/medications/<medication_id>', methods=['DELETE'])
+@authenticate
+def delete_medication(patient_id, medication_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        existing = _fetch_medication(medication_id, patient_id)
+        if not existing:
+            return jsonify({'error': 'Medication not found'}), 404
+
+        deleted = execute_query(
+            'DELETE FROM medications WHERE id = %s AND patient_id = %s RETURNING id',
+            (medication_id, patient_id),
+            fetch_one=True,
+        )
+        if not deleted:
+            return jsonify({'error': 'Medication not found'}), 404
+
+        log_data_access(request.user['id'], 'medications', medication_id, 'DELETE', request)
+        return jsonify({'message': 'Medication deleted'}), 200
+    except Exception:
+        current_app.logger.exception('Medication deletion error')
+        return jsonify({'error': FAILED_DELETE_MEDICATION_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/problems', methods=['GET'])
+@authenticate
+def list_problems(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        rows = execute_query(
+            f"{PROBLEM_SELECT} WHERE p.patient_id = %s ORDER BY p.status, p.name",
+            (patient_id,),
+            fetch_all=True,
+        ) or []
+        log_data_access(request.user['id'], 'problems', patient_id, 'VIEW', request)
+        return jsonify({'problems': [serialize_row(row) for row in rows]}), 200
+    except Exception:
+        current_app.logger.exception('Problems list error')
+        return jsonify({'error': FAILED_RETRIEVE_PROBLEMS_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/problems', methods=['POST'])
+@authenticate
+def create_problem(patient_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        if not _patient_exists(patient_id):
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        data = request.get_json(silent=True) or {}
+        name = (data.get('name') or '').strip()
+        if not name:
+            return jsonify({'error': 'name is required'}), 400
+
+        status = (data.get('status') or 'active').strip().lower()
+        if status not in PROBLEM_STATUSES:
+            return jsonify({'error': 'status must be active, resolved, or inactive'}), 400
+
+        onset_date, onset_error = _parse_optional_date(data.get('onset_date'), 'onset_date')
+        if onset_error:
+            return onset_error
+        resolved_date, resolved_error = _parse_optional_date(data.get('resolved_date'), 'resolved_date')
+        if resolved_error:
+            return resolved_error
+
+        created = execute_query(
+            """
+            INSERT INTO problems (
+                patient_id, name, status, onset_date, resolved_date, notes, created_by_doctor_id
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                patient_id,
+                name,
+                status,
+                onset_date,
+                resolved_date,
+                data.get('notes'),
+                doctor_id,
+            ),
+            fetch_one=True,
+        )
+        problem = _fetch_problem(created['id'], patient_id)
+        log_data_access(request.user['id'], 'problems', created['id'], 'CREATE', request)
+        return jsonify({'problem': serialize_row(problem)}), 201
+    except Exception:
+        current_app.logger.exception('Problem creation error')
+        return jsonify({'error': FAILED_CREATE_PROBLEM_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/problems/<problem_id>', methods=['PUT'])
+@authenticate
+def update_problem(patient_id, problem_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        existing = _fetch_problem(problem_id, patient_id)
+        if not existing:
+            return jsonify({'error': 'Problem not found'}), 404
+
+        data = request.get_json(silent=True) or {}
+        name = data.get('name', existing['name'])
+        name = (name or '').strip()
+        if not name:
+            return jsonify({'error': 'name cannot be empty'}), 400
+
+        status = (data.get('status', existing['status']) or 'active').strip().lower()
+        if status not in PROBLEM_STATUSES:
+            return jsonify({'error': 'status must be active, resolved, or inactive'}), 400
+
+        onset_date, onset_error = _parse_optional_date(
+            data['onset_date'] if 'onset_date' in data else existing.get('onset_date'),
+            'onset_date',
+        )
+        if onset_error:
+            return onset_error
+        resolved_date, resolved_error = _parse_optional_date(
+            data['resolved_date'] if 'resolved_date' in data else existing.get('resolved_date'),
+            'resolved_date',
+        )
+        if resolved_error:
+            return resolved_error
+
+        notes = data['notes'] if 'notes' in data else existing.get('notes')
+
+        updated = execute_query(
+            """
+            UPDATE problems
+            SET name = %s, status = %s, onset_date = %s, resolved_date = %s,
+                notes = %s, updated_at = NOW()
+            WHERE id = %s AND patient_id = %s
+            RETURNING id
+            """,
+            (name, status, onset_date, resolved_date, notes, problem_id, patient_id),
+            fetch_one=True,
+        )
+        if not updated:
+            return jsonify({'error': 'Problem not found'}), 404
+
+        problem = _fetch_problem(problem_id, patient_id)
+        log_data_access(request.user['id'], 'problems', problem_id, 'UPDATE', request)
+        return jsonify({'problem': serialize_row(problem)}), 200
+    except Exception:
+        current_app.logger.exception('Problem update error')
+        return jsonify({'error': FAILED_UPDATE_PROBLEM_ERROR}), 500
+
+
+@chart_bp.route('/<patient_id>/problems/<problem_id>', methods=['DELETE'])
+@authenticate
+def delete_problem(patient_id, problem_id):
+    try:
+        doctor_id, error_response = _require_doctor()
+        if error_response:
+            return error_response
+
+        existing = _fetch_problem(problem_id, patient_id)
+        if not existing:
+            return jsonify({'error': 'Problem not found'}), 404
+
+        deleted = execute_query(
+            'DELETE FROM problems WHERE id = %s AND patient_id = %s RETURNING id',
+            (problem_id, patient_id),
+            fetch_one=True,
+        )
+        if not deleted:
+            return jsonify({'error': 'Problem not found'}), 404
+
+        log_data_access(request.user['id'], 'problems', problem_id, 'DELETE', request)
+        return jsonify({'message': 'Problem deleted'}), 200
+    except Exception:
+        current_app.logger.exception('Problem deletion error')
+        return jsonify({'error': FAILED_DELETE_PROBLEM_ERROR}), 500

--- a/api/routes/documents.py
+++ b/api/routes/documents.py
@@ -22,6 +22,13 @@ FAILED_RETRIEVE_DOCUMENTS_ERROR = 'Failed to retrieve documents'
 FAILED_UPLOAD_DOCUMENTS_ERROR = 'Failed to upload documents'
 FAILED_RENAME_DOCUMENT_ERROR = 'Failed to rename document'
 FAILED_DELETE_DOCUMENT_ERROR = 'Failed to delete document'
+FAILED_UPDATE_VISIBILITY_ERROR = 'Failed to update document visibility'
+
+DOCUMENT_COLUMNS = """
+    id, patient_id, doctor_id, document_type, title, description,
+    file_path, file_name, file_size, document_date, patient_visible,
+    created_at, updated_at
+"""
 
 DOCUMENTS_STORAGE_BACKEND = (os.getenv('DOCUMENTS_STORAGE_BACKEND') or 'local').strip().lower()
 LOCAL_UPLOAD_DIR = Path((os.getenv('DOCUMENTS_LOCAL_DIR') or str(Path.home() / 'hhs-documents')).strip())
@@ -178,12 +185,20 @@ def serialize_document(doc):
     return result
 
 
+def _parse_patient_visible(raw_value, default=False):
+    if raw_value is None:
+        return default
+    if isinstance(raw_value, bool):
+        return raw_value
+    return str(raw_value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
 @documents_bp.route('/<patient_id>', methods=['GET'])
 @authenticate
 def list_documents(patient_id):
     """
     GET /api/documents/<patient_id>
-    List all documents for a patient (patients view own, providers view any)
+    List documents for a patient (patients see only patient_visible docs)
     """
     try:
         user = request.user
@@ -194,17 +209,21 @@ def list_documents(patient_id):
             patient = execute_query(patient_query, (user['id'],), fetch_one=True)
             if not patient or patient['id'] != patient_id:
                 return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
-        elif user.get('role') != 'doctor':
+            query = f"""
+                SELECT {DOCUMENT_COLUMNS}
+                FROM medical_documents
+                WHERE patient_id = %s AND patient_visible = TRUE
+                ORDER BY created_at DESC
+            """
+        elif user.get('role') == 'doctor':
+            query = f"""
+                SELECT {DOCUMENT_COLUMNS}
+                FROM medical_documents
+                WHERE patient_id = %s
+                ORDER BY created_at DESC
+            """
+        else:
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
-        
-        query = """
-            SELECT id, patient_id, doctor_id, document_type, title, description,
-                   file_path, file_name, file_size, document_date,
-                   created_at, updated_at
-            FROM medical_documents
-            WHERE patient_id = %s
-            ORDER BY created_at DESC
-        """
         
         documents = execute_query(query, (patient_id,), fetch_all=True)
         
@@ -243,6 +262,11 @@ def upload_document(patient_id):
         if not files or all(f.filename == '' for f in files):
             return jsonify({'error': 'No files selected'}), 400
 
+        patient_visible = _parse_patient_visible(
+            request.form.get('patient_visible'),
+            default=False,
+        )
+
         uploaded = []
         errors = []
 
@@ -263,20 +287,18 @@ def upload_document(patient_id):
             doc_type = DOCUMENT_TYPE_MAP.get(file_ext, 'other')
 
             # Insert into database
-            insert_query = """
+            insert_query = f"""
                 INSERT INTO medical_documents
                 (patient_id, doctor_id, document_type, title, file_path, file_name, 
-                 file_size, document_date)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, CURRENT_DATE)
-                RETURNING id, patient_id, doctor_id, document_type, title, description,
-                          file_path, file_name, file_size, document_date,
-                          created_at, updated_at
+                 file_size, document_date, patient_visible)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, CURRENT_DATE, %s)
+                RETURNING {DOCUMENT_COLUMNS}
             """
             
             doc = execute_query(
                 insert_query,
                 (patient_id, doctor_id, doc_type, original_name, stored_path,
-                 original_name, file_size),
+                 original_name, file_size, patient_visible),
                 fetch_one=True
             )
 
@@ -314,13 +336,11 @@ def rename_document(doc_id):
             return jsonify({'error': 'Title is required'}), 400
         
         # Update document title
-        update_query = """
+        update_query = f"""
             UPDATE medical_documents
             SET title = %s, updated_at = CURRENT_TIMESTAMP
             WHERE id = %s
-            RETURNING id, patient_id, doctor_id, document_type, title, description,
-                      file_path, file_name, file_size, document_date,
-                      created_at, updated_at
+            RETURNING {DOCUMENT_COLUMNS}
         """
         
         doc = execute_query(update_query, (new_title, doc_id), fetch_one=True)
@@ -336,6 +356,46 @@ def rename_document(doc_id):
     except Exception:
         current_app.logger.exception('Document rename error')
         return jsonify({'error': FAILED_RENAME_DOCUMENT_ERROR}), 500
+
+
+@documents_bp.route('/<doc_id>/visibility', methods=['PUT'])
+@authenticate
+def update_document_visibility(doc_id):
+    """
+    PUT /api/documents/<doc_id>/visibility
+    Toggle whether a document is visible to the patient
+    """
+    try:
+        user = request.user
+
+        if user.get('role') != 'doctor':
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+
+        data = request.get_json(silent=True) or {}
+        if 'patient_visible' not in data:
+            return jsonify({'error': 'patient_visible is required'}), 400
+
+        patient_visible = _parse_patient_visible(data.get('patient_visible'), default=False)
+
+        update_query = f"""
+            UPDATE medical_documents
+            SET patient_visible = %s, updated_at = CURRENT_TIMESTAMP
+            WHERE id = %s
+            RETURNING {DOCUMENT_COLUMNS}
+        """
+        doc = execute_query(update_query, (patient_visible, doc_id), fetch_one=True)
+
+        if not doc:
+            return jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404
+
+        return jsonify({
+            'message': 'Document visibility updated',
+            'document': serialize_document(doc),
+        }), 200
+
+    except Exception:
+        current_app.logger.exception('Document visibility update error')
+        return jsonify({'error': FAILED_UPDATE_VISIBILITY_ERROR}), 500
 
 
 @documents_bp.route('/<doc_id>', methods=['DELETE'])
@@ -385,17 +445,25 @@ def download_document(doc_id):
         user = request.user
         
         # Get document
-        query = "SELECT id, file_path, file_name, title, patient_id FROM medical_documents WHERE id = %s"
+        query = """
+            SELECT id, file_path, file_name, title, patient_id, patient_visible
+            FROM medical_documents
+            WHERE id = %s
+        """
         doc = execute_query(query, (doc_id,), fetch_one=True)
         
         if not doc:
             return jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404
         
-        # Patient can only download their own documents
+        # Patient can only download their own patient-visible documents
         if user.get('role') == 'patient':
             patient_query = "SELECT id FROM patients WHERE user_id = %s"
             patient = execute_query(patient_query, (user['id'],), fetch_one=True)
-            if not patient or patient['id'] != doc['patient_id']:
+            if (
+                not patient
+                or patient['id'] != doc['patient_id']
+                or not doc.get('patient_visible')
+            ):
                 return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
         elif user.get('role') != 'doctor':
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403

--- a/api/tests/test_chart.py
+++ b/api/tests/test_chart.py
@@ -1,0 +1,221 @@
+from api.db.connection import execute_query
+from api.tests.conftest import login_as, requires_db
+
+
+def _get_patient_id(username='patient1'):
+    patient = execute_query(
+        """
+        SELECT p.id
+        FROM patients p
+        JOIN users u ON u.id = p.user_id
+        WHERE u.username = %s
+        """,
+        (username,),
+        fetch_one=True,
+    )
+    assert patient is not None, f'Expected patient for {username}'
+    return patient['id']
+
+
+def _count_audit_logs(action, resource_type=None, resource_id=None):
+    clauses = ['action = %s']
+    params = [action]
+    if resource_type:
+        clauses.append('resource_type = %s')
+        params.append(resource_type)
+    if resource_id:
+        clauses.append('resource_id = %s')
+        params.append(str(resource_id))
+    row = execute_query(
+        f"SELECT COUNT(*) AS count FROM audit_logs WHERE {' AND '.join(clauses)}",
+        tuple(params),
+        fetch_one=True,
+    )
+    return row['count'] if row else 0
+
+
+@requires_db
+def test_patient_cannot_access_chart_summary(client):
+    headers = login_as(client, 'patient1', 'Patient123!')
+    patient_id = _get_patient_id()
+    response = client.get(f'/api/chart/{patient_id}/summary', headers=headers)
+    assert response.status_code == 403, response.get_json()
+
+
+@requires_db
+def test_doctor_chart_summary_includes_active_items(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+
+    response = client.get(f'/api/chart/{patient_id}/summary', headers=headers)
+    assert response.status_code == 200, response.get_json()
+    summary = response.get_json()['summary']
+
+    assert 'allergies' in summary
+    assert 'medications' in summary
+    assert 'problems' in summary
+    assert summary['allergy_count'] == len(summary['allergies'])
+    assert summary['medication_count'] == len(summary['medications'])
+    assert summary['problem_count'] == len(summary['problems'])
+    assert _count_audit_logs('DATA_VIEW', 'chart_summary', patient_id) >= 1
+
+
+@requires_db
+def test_allergy_crud_flow(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+
+    create_response = client.post(
+        f'/api/chart/{patient_id}/allergies',
+        headers=headers,
+        json={
+            'allergen': 'Sulfa Drugs',
+            'reaction': 'Itching',
+            'severity': 'mild',
+            'status': 'active',
+            'notes': 'Avoid sulfonamides',
+        },
+    )
+    assert create_response.status_code == 201, create_response.get_json()
+    allergy = create_response.get_json()['allergy']
+    allergy_id = allergy['id']
+    assert allergy['allergen'] == 'Sulfa Drugs'
+    assert allergy['severity'] == 'mild'
+    assert _count_audit_logs('DATA_CREATE', 'allergies', allergy_id) >= 1
+
+    update_response = client.put(
+        f'/api/chart/{patient_id}/allergies/{allergy_id}',
+        headers=headers,
+        json={'severity': 'moderate', 'status': 'inactive'},
+    )
+    assert update_response.status_code == 200, update_response.get_json()
+    updated = update_response.get_json()['allergy']
+    assert updated['severity'] == 'moderate'
+    assert updated['status'] == 'inactive'
+
+    list_response = client.get(f'/api/chart/{patient_id}/allergies', headers=headers)
+    assert list_response.status_code == 200
+    ids = [row['id'] for row in list_response.get_json()['allergies']]
+    assert allergy_id in ids
+
+    delete_response = client.delete(
+        f'/api/chart/{patient_id}/allergies/{allergy_id}',
+        headers=headers,
+    )
+    assert delete_response.status_code == 200, delete_response.get_json()
+    assert _count_audit_logs('DATA_DELETE', 'allergies', allergy_id) >= 1
+
+
+@requires_db
+def test_medication_and_problem_crud(client):
+    headers = login_as(client, 'doctor1')
+    patient_id = _get_patient_id()
+
+    med_response = client.post(
+        f'/api/chart/{patient_id}/medications',
+        headers=headers,
+        json={
+            'name': 'Atorvastatin',
+            'dosage': '20 mg',
+            'frequency': 'Nightly',
+            'route': 'Oral',
+            'status': 'active',
+            'start_date': '2026-01-01',
+        },
+    )
+    assert med_response.status_code == 201, med_response.get_json()
+    medication = med_response.get_json()['medication']
+    assert medication['name'] == 'Atorvastatin'
+
+    med_update = client.put(
+        f'/api/chart/{patient_id}/medications/{medication["id"]}',
+        headers=headers,
+        json={'status': 'discontinued', 'end_date': '2026-07-01'},
+    )
+    assert med_update.status_code == 200, med_update.get_json()
+    assert med_update.get_json()['medication']['status'] == 'discontinued'
+
+    problem_response = client.post(
+        f'/api/chart/{patient_id}/problems',
+        headers=headers,
+        json={
+            'name': 'Hyperlipidemia',
+            'status': 'active',
+            'onset_date': '2025-12-01',
+            'notes': 'Diet and statin therapy',
+        },
+    )
+    assert problem_response.status_code == 201, problem_response.get_json()
+    problem = problem_response.get_json()['problem']
+
+    problem_update = client.put(
+        f'/api/chart/{patient_id}/problems/{problem["id"]}',
+        headers=headers,
+        json={'status': 'resolved', 'resolved_date': '2026-07-01'},
+    )
+    assert problem_update.status_code == 200, problem_update.get_json()
+    assert problem_update.get_json()['problem']['status'] == 'resolved'
+
+    assert client.delete(
+        f'/api/chart/{patient_id}/medications/{medication["id"]}',
+        headers=headers,
+    ).status_code == 200
+    assert client.delete(
+        f'/api/chart/{patient_id}/problems/{problem["id"]}',
+        headers=headers,
+    ).status_code == 200
+
+
+@requires_db
+def test_document_visibility_gates_patient_access(client):
+    doctor_headers = login_as(client, 'doctor1')
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    patient_id = _get_patient_id()
+
+    # Ensure at least one provider-only and one visible document exist via visibility toggle
+    doctor_list = client.get(f'/api/documents/{patient_id}', headers=doctor_headers)
+    assert doctor_list.status_code == 200, doctor_list.get_json()
+    docs = doctor_list.get_json()['documents']
+    assert len(docs) >= 1
+
+    # Pick first doc and force provider-only, then verify patient cannot see it
+    target = docs[0]
+    hide = client.put(
+        f'/api/documents/{target["id"]}/visibility',
+        headers=doctor_headers,
+        json={'patient_visible': False},
+    )
+    assert hide.status_code == 200, hide.get_json()
+    assert hide.get_json()['document']['patient_visible'] is False
+
+    patient_list_hidden = client.get(f'/api/documents/{patient_id}', headers=patient_headers)
+    assert patient_list_hidden.status_code == 200, patient_list_hidden.get_json()
+    patient_ids = {d['id'] for d in patient_list_hidden.get_json()['documents']}
+    assert target['id'] not in patient_ids
+
+    download_hidden = client.get(
+        f'/api/documents/download/{target["id"]}',
+        headers=patient_headers,
+    )
+    assert download_hidden.status_code == 403, download_hidden.get_json()
+
+    show = client.put(
+        f'/api/documents/{target["id"]}/visibility',
+        headers=doctor_headers,
+        json={'patient_visible': True},
+    )
+    assert show.status_code == 200, show.get_json()
+    assert show.get_json()['document']['patient_visible'] is True
+
+    patient_list_visible = client.get(f'/api/documents/{patient_id}', headers=patient_headers)
+    assert patient_list_visible.status_code == 200, patient_list_visible.get_json()
+    visible_ids = {d['id'] for d in patient_list_visible.get_json()['documents']}
+    assert target['id'] in visible_ids
+
+    # Patient cannot toggle visibility
+    patient_toggle = client.put(
+        f'/api/documents/{target["id"]}/visibility',
+        headers=patient_headers,
+        json={'patient_visible': False},
+    )
+    assert patient_toggle.status_code == 403, patient_toggle.get_json()

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -100,6 +100,57 @@ CREATE TABLE IF NOT EXISTS medical_documents (
     file_name TEXT NOT NULL,
     file_size BIGINT,
     document_date DATE,
+    patient_visible BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE medical_documents
+    ADD COLUMN IF NOT EXISTS patient_visible BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE IF NOT EXISTS allergies (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    patient_id UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    allergen TEXT NOT NULL,
+    reaction TEXT,
+    severity TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (severity IN ('mild', 'moderate', 'severe', 'unknown')),
+    status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'inactive')),
+    notes TEXT,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS medications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    patient_id UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    dosage TEXT,
+    frequency TEXT,
+    route TEXT,
+    status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'discontinued', 'completed')),
+    start_date DATE,
+    end_date DATE,
+    notes TEXT,
+    prescribed_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS problems (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    patient_id UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'resolved', 'inactive')),
+    onset_date DATE,
+    resolved_date DATE,
+    notes TEXT,
+    created_by_doctor_id UUID REFERENCES doctors(id) ON DELETE SET NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -148,6 +199,11 @@ CREATE INDEX IF NOT EXISTS idx_appointments_patient_date ON appointments(patient
 CREATE INDEX IF NOT EXISTS idx_appointments_doctor_date ON appointments(doctor_id, appointment_date DESC);
 CREATE INDEX IF NOT EXISTS idx_events_doctor_date ON events(doctor_id, event_date);
 CREATE INDEX IF NOT EXISTS idx_documents_patient ON medical_documents(patient_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_documents_patient_visible
+    ON medical_documents(patient_id, patient_visible, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_allergies_patient ON allergies(patient_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_medications_patient ON medications(patient_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_problems_patient ON problems(patient_id, status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_user_sessions_token ON user_sessions(session_token);
 CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions(user_id);

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -353,3 +353,105 @@ WHERE c.type = 'channel'
   AND NOT EXISTS (
       SELECT 1 FROM messages m WHERE m.conversation_id = c.id
   );
+
+-- Sample chart data for patient1 (provider chart demo).
+INSERT INTO allergies (
+    patient_id, allergen, reaction, severity, status, notes, created_by_doctor_id
+)
+SELECT p.id, a.allergen, a.reaction, a.severity, a.status, a.notes, d.id
+FROM (
+    VALUES
+        ('Penicillin', 'Rash and hives', 'moderate', 'active', 'Avoid all beta-lactam antibiotics'),
+        ('Peanuts', 'Anaphylaxis', 'severe', 'active', 'Carries epinephrine auto-injector')
+) AS a(allergen, reaction, severity, status, notes)
+JOIN users pu ON pu.username = 'patient1'
+JOIN patients p ON p.user_id = pu.id
+JOIN users du ON du.username = 'doctor1'
+JOIN doctors d ON d.user_id = du.id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM allergies existing
+    WHERE existing.patient_id = p.id
+      AND existing.allergen = a.allergen
+);
+
+INSERT INTO medications (
+    patient_id, name, dosage, frequency, route, status, start_date, notes, prescribed_by_doctor_id
+)
+SELECT p.id, m.name, m.dosage, m.frequency, m.route, m.status, m.start_date, m.notes, d.id
+FROM (
+    VALUES
+        ('Lisinopril', '10 mg', 'Once daily', 'Oral', 'active', '2025-01-15'::date, 'Blood pressure control'),
+        ('Metformin', '500 mg', 'Twice daily', 'Oral', 'active', '2024-06-01'::date, 'Type 2 diabetes')
+) AS m(name, dosage, frequency, route, status, start_date, notes)
+JOIN users pu ON pu.username = 'patient1'
+JOIN patients p ON p.user_id = pu.id
+JOIN users du ON du.username = 'doctor1'
+JOIN doctors d ON d.user_id = du.id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM medications existing
+    WHERE existing.patient_id = p.id
+      AND existing.name = m.name
+);
+
+INSERT INTO problems (
+    patient_id, name, status, onset_date, notes, created_by_doctor_id
+)
+SELECT p.id, pr.name, pr.status, pr.onset_date, pr.notes, d.id
+FROM (
+    VALUES
+        ('Hypertension', 'active', '2024-11-01'::date, 'Well controlled on lisinopril'),
+        ('Type 2 Diabetes Mellitus', 'active', '2024-05-20'::date, 'A1C trending down')
+) AS pr(name, status, onset_date, notes)
+JOIN users pu ON pu.username = 'patient1'
+JOIN patients p ON p.user_id = pu.id
+JOIN users du ON du.username = 'doctor1'
+JOIN doctors d ON d.user_id = du.id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM problems existing
+    WHERE existing.patient_id = p.id
+      AND existing.name = pr.name
+);
+
+-- Sample documents: one patient-visible, one provider-only.
+INSERT INTO medical_documents (
+    patient_id, doctor_id, document_type, title, description,
+    file_path, file_name, file_size, document_date, patient_visible
+)
+SELECT p.id, d.id, doc.document_type, doc.title, doc.description,
+       doc.file_path, doc.file_name, doc.file_size, doc.document_date, doc.patient_visible
+FROM (
+    VALUES
+        (
+            'lab_result',
+            'Annual Labs Summary',
+            'Shared lab summary for patient portal',
+            'seed/annual-labs-summary.txt',
+            'annual-labs-summary.txt',
+            128,
+            '2026-06-01'::date,
+            TRUE
+        ),
+        (
+            'document',
+            'Internal Chart Review Notes',
+            'Provider-only clinical notes',
+            'seed/internal-chart-review.txt',
+            'internal-chart-review.txt',
+            256,
+            '2026-06-15'::date,
+            FALSE
+        )
+) AS doc(document_type, title, description, file_path, file_name, file_size, document_date, patient_visible)
+JOIN users pu ON pu.username = 'patient1'
+JOIN patients p ON p.user_id = pu.id
+JOIN users du ON du.username = 'doctor1'
+JOIN doctors d ON d.user_id = du.id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM medical_documents existing
+    WHERE existing.patient_id = p.id
+      AND existing.title = doc.title
+);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -225,6 +225,180 @@ export const patientPropertiesApi = {
 };
 
 /**
+ * Provider chart API (allergies, medications, problems, summary)
+ */
+export const chartApi = {
+  async getSummary(patientId: string) {
+    return request<{ summary: import('@/types').ChartSummary }>(
+      `/api/chart/${patientId}/summary`,
+      { method: 'GET' },
+    );
+  },
+
+  async listAllergies(patientId: string) {
+    return request<{ allergies: import('@/types').Allergy[] }>(
+      `/api/chart/${patientId}/allergies`,
+      { method: 'GET' },
+    );
+  },
+
+  async createAllergy(
+    patientId: string,
+    payload: {
+      allergen: string
+      reaction?: string
+      severity?: import('@/types').AllergySeverity
+      status?: import('@/types').AllergyStatus
+      notes?: string
+    },
+  ) {
+    return request<{ allergy: import('@/types').Allergy }>(
+      `/api/chart/${patientId}/allergies`,
+      { method: 'POST', body: JSON.stringify(payload) },
+    );
+  },
+
+  async updateAllergy(
+    patientId: string,
+    allergyId: string,
+    payload: Partial<{
+      allergen: string
+      reaction: string | null
+      severity: import('@/types').AllergySeverity
+      status: import('@/types').AllergyStatus
+      notes: string | null
+    }>,
+  ) {
+    return request<{ allergy: import('@/types').Allergy }>(
+      `/api/chart/${patientId}/allergies/${allergyId}`,
+      { method: 'PUT', body: JSON.stringify(payload) },
+    );
+  },
+
+  async deleteAllergy(patientId: string, allergyId: string) {
+    return request<{ message: string }>(
+      `/api/chart/${patientId}/allergies/${allergyId}`,
+      { method: 'DELETE' },
+    );
+  },
+
+  async listMedications(patientId: string) {
+    return request<{ medications: import('@/types').Medication[] }>(
+      `/api/chart/${patientId}/medications`,
+      { method: 'GET' },
+    );
+  },
+
+  async createMedication(
+    patientId: string,
+    payload: {
+      name: string
+      dosage?: string
+      frequency?: string
+      route?: string
+      status?: import('@/types').MedicationStatus
+      start_date?: string | null
+      end_date?: string | null
+      notes?: string
+    },
+  ) {
+    return request<{ medication: import('@/types').Medication }>(
+      `/api/chart/${patientId}/medications`,
+      { method: 'POST', body: JSON.stringify(payload) },
+    );
+  },
+
+  async updateMedication(
+    patientId: string,
+    medicationId: string,
+    payload: Partial<{
+      name: string
+      dosage: string | null
+      frequency: string | null
+      route: string | null
+      status: import('@/types').MedicationStatus
+      start_date: string | null
+      end_date: string | null
+      notes: string | null
+    }>,
+  ) {
+    return request<{ medication: import('@/types').Medication }>(
+      `/api/chart/${patientId}/medications/${medicationId}`,
+      { method: 'PUT', body: JSON.stringify(payload) },
+    );
+  },
+
+  async deleteMedication(patientId: string, medicationId: string) {
+    return request<{ message: string }>(
+      `/api/chart/${patientId}/medications/${medicationId}`,
+      { method: 'DELETE' },
+    );
+  },
+
+  async listProblems(patientId: string) {
+    return request<{ problems: import('@/types').Problem[] }>(
+      `/api/chart/${patientId}/problems`,
+      { method: 'GET' },
+    );
+  },
+
+  async createProblem(
+    patientId: string,
+    payload: {
+      name: string
+      status?: import('@/types').ProblemStatus
+      onset_date?: string | null
+      resolved_date?: string | null
+      notes?: string
+    },
+  ) {
+    return request<{ problem: import('@/types').Problem }>(
+      `/api/chart/${patientId}/problems`,
+      { method: 'POST', body: JSON.stringify(payload) },
+    );
+  },
+
+  async updateProblem(
+    patientId: string,
+    problemId: string,
+    payload: Partial<{
+      name: string
+      status: import('@/types').ProblemStatus
+      onset_date: string | null
+      resolved_date: string | null
+      notes: string | null
+    }>,
+  ) {
+    return request<{ problem: import('@/types').Problem }>(
+      `/api/chart/${patientId}/problems/${problemId}`,
+      { method: 'PUT', body: JSON.stringify(payload) },
+    );
+  },
+
+  async deleteProblem(patientId: string, problemId: string) {
+    return request<{ message: string }>(
+      `/api/chart/${patientId}/problems/${problemId}`,
+      { method: 'DELETE' },
+    );
+  },
+};
+
+/**
+ * Documents API helpers (visibility toggle)
+ */
+export const documentsApi = {
+  async setVisibility(docId: string, patientVisible: boolean) {
+    return request<{ document: import('@/types').PatientDocument; message: string }>(
+      `/api/documents/${docId}/visibility`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({ patient_visible: patientVisible }),
+      },
+    );
+  },
+};
+
+/**
  * In-app messaging API (DMs, channels, threads)
  */
 export const messagesApi = {
@@ -323,5 +497,7 @@ export default {
   auth: authApi,
   health: healthApi,
   patientProperties: patientPropertiesApi,
+  chart: chartApi,
+  documents: documentsApi,
   messages: messagesApi,
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,8 +61,69 @@ export interface PatientDocument {
   file_name: string
   file_size: number
   document_date: string
+  patient_visible?: boolean
   created_at?: string
   updated_at?: string
+}
+
+export type AllergySeverity = 'mild' | 'moderate' | 'severe' | 'unknown'
+export type AllergyStatus = 'active' | 'inactive'
+export type MedicationStatus = 'active' | 'discontinued' | 'completed'
+export type ProblemStatus = 'active' | 'resolved' | 'inactive'
+
+export interface Allergy {
+  id: string
+  patient_id: string
+  allergen: string
+  reaction?: string | null
+  severity: AllergySeverity
+  status: AllergyStatus
+  notes?: string | null
+  recorded_at?: string
+  created_by_doctor_id?: string | null
+  created_by_name?: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export interface Medication {
+  id: string
+  patient_id: string
+  name: string
+  dosage?: string | null
+  frequency?: string | null
+  route?: string | null
+  status: MedicationStatus
+  start_date?: string | null
+  end_date?: string | null
+  notes?: string | null
+  prescribed_by_doctor_id?: string | null
+  prescribed_by_name?: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export interface Problem {
+  id: string
+  patient_id: string
+  name: string
+  status: ProblemStatus
+  onset_date?: string | null
+  resolved_date?: string | null
+  notes?: string | null
+  created_by_doctor_id?: string | null
+  created_by_name?: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export interface ChartSummary {
+  allergies: Allergy[]
+  medications: Medication[]
+  problems: Problem[]
+  allergy_count: number
+  medication_count: number
+  problem_count: number
 }
 
 export interface MedicalDocument {

--- a/src/views/PatientDashboard.vue
+++ b/src/views/PatientDashboard.vue
@@ -131,7 +131,8 @@
           <p>Loading documents...</p>
         </div>
         <div v-else-if="documents.length === 0" class="empty-state">
-          <p>No medical documents available</p>
+          <p>No shared medical documents available</p>
+          <p class="empty-hint">Documents shared by your care team will appear here.</p>
         </div>
         <div v-else class="documents-list">
           <div 
@@ -524,6 +525,12 @@ watch(activeTab, (newTab) => {
   padding: 60px 20px;
   color: #999;
   font-size: 16px;
+}
+
+.empty-hint {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #9ca3af;
 }
 
 .appointments-list, .documents-list {

--- a/src/views/PatientsView.vue
+++ b/src/views/PatientsView.vue
@@ -30,108 +30,273 @@
 
       <section class="patient-detail" v-if="selectedPatient">
         <div class="detail-header">
-          <h2>{{ selectedPatient.first_name }} {{ selectedPatient.last_name }}</h2>
+          <div>
+            <h2>{{ selectedPatient.first_name }} {{ selectedPatient.last_name }}</h2>
+            <div class="banner-meta">
+              <span>DOB: {{ formatDate(selectedPatient.date_of_birth) }}</span>
+              <span v-if="selectedPatient.phone">Phone: {{ selectedPatient.phone }}</span>
+            </div>
+          </div>
           <span class="badge" :class="{ linked: !!selectedPatient.user_id }">
             {{ selectedPatient.user_id ? 'Portal Linked' : 'No Portal Account' }}
           </span>
         </div>
 
-        <div class="detail-grid">
-          <div class="detail-card">
-            <p class="detail-label">Date of Birth</p>
-            <div>{{ formatDate(selectedPatient.date_of_birth) }}</div>
-          </div>
-          <div class="detail-card">
-            <p class="detail-label">Phone</p>
-            <div>{{ selectedPatient.phone }}</div>
-          </div>
-          <div class="detail-card">
-            <p class="detail-label">Address</p>
-            <div>{{ selectedPatient.address || '—' }}</div>
-          </div>
-          <div class="detail-card">
-            <p class="detail-label">Emergency Contact</p>
-            <div>
-              {{ selectedPatient.emergency_contact_name || '—' }}
-              <span v-if="selectedPatient.emergency_contact_phone">
-                ({{ selectedPatient.emergency_contact_phone }})
-              </span>
+        <nav class="chart-tabs" aria-label="Patient chart sections">
+          <button
+            v-for="tab in chartTabs"
+            :key="tab.id"
+            type="button"
+            class="chart-tab"
+            :class="{ active: activeChartTab === tab.id }"
+            @click="activeChartTab = tab.id"
+          >
+            {{ tab.label }}
+          </button>
+        </nav>
+
+        <div v-if="activeChartTab === 'summary'" class="chart-panel">
+          <div v-if="summaryLoading" class="state">Loading summary...</div>
+          <div v-else-if="summaryError" class="state error">{{ summaryError }}</div>
+          <div v-else class="summary-widgets">
+            <div class="summary-widget">
+              <h3>Allergies</h3>
+              <p v-if="!chartSummary || chartSummary.allergy_count === 0" class="widget-empty">No active allergies.</p>
+              <ul v-else>
+                <li v-for="item in chartSummary.allergies" :key="item.id">
+                  <strong>{{ item.allergen }}</strong>
+                  <span v-if="item.reaction"> — {{ item.reaction }}</span>
+                  <span class="severity"> ({{ item.severity }})</span>
+                </li>
+              </ul>
+            </div>
+            <div class="summary-widget">
+              <h3>Medications</h3>
+              <p v-if="!chartSummary || chartSummary.medication_count === 0" class="widget-empty">No current medications.</p>
+              <ul v-else>
+                <li v-for="item in chartSummary.medications" :key="item.id">
+                  <strong>{{ item.name }}</strong>
+                  <span v-if="item.dosage"> — {{ item.dosage }}</span>
+                  <span v-if="item.frequency">, {{ item.frequency }}</span>
+                </li>
+              </ul>
+            </div>
+            <div class="summary-widget">
+              <h3>Problems</h3>
+              <p v-if="!chartSummary || chartSummary.problem_count === 0" class="widget-empty">No active problems.</p>
+              <ul v-else>
+                <li v-for="item in chartSummary.problems" :key="item.id">
+                  <strong>{{ item.name }}</strong>
+                </li>
+              </ul>
             </div>
           </div>
-          <div class="detail-card" v-if="selectedPatient.portal_email">
-            <p class="detail-label">Portal Email</p>
-            <div>{{ selectedPatient.portal_email }}</div>
-          </div>
-        </div>
 
-        <div class="properties-section">
-          <div class="properties-header">
-            <h3>Notes</h3>
-            <button class="add-btn" @click="openAddProperty">+ Add</button>
-          </div>
-
-          <div v-if="propertiesLoading" class="state">Loading properties...</div>
-          <div v-else-if="propertiesError" class="state error">{{ propertiesError }}</div>
-          <div v-else-if="patientProperties.length === 0" class="state">No properties yet.</div>
-
-          <div class="accordion" v-else>
-            <div
-              v-for="prop in patientProperties"
-              :key="prop.property_id"
-              class="accordion-item"
-            >
-              <button class="accordion-header" @click="toggleProperty(prop.property_id)">
-                <span>{{ getPropertyDisplayName(prop) }}</span>
-                <span class="accordion-actions">
-                  <span v-if="getSaveStatus(prop.property_id) !== 'idle'" class="note-save-status-inline" :class="getSaveStatus(prop.property_id)">
-                    {{ saveStatusLabel(prop.property_id) }}
-                  </span>
-                  <span class="toggle-indicator">
-                    {{ expandedProperties.has(prop.property_id) ? '−' : '+' }}
-                  </span>
-                  <button class="delete-btn" @click.stop="confirmDelete(prop)">Delete</button>
+          <div class="detail-grid demographics-grid">
+            <div class="detail-card">
+              <p class="detail-label">Date of Birth</p>
+              <div>{{ formatDate(selectedPatient.date_of_birth) }}</div>
+            </div>
+            <div class="detail-card">
+              <p class="detail-label">Phone</p>
+              <div>{{ selectedPatient.phone }}</div>
+            </div>
+            <div class="detail-card">
+              <p class="detail-label">Address</p>
+              <div>{{ selectedPatient.address || '—' }}</div>
+            </div>
+            <div class="detail-card">
+              <p class="detail-label">Emergency Contact</p>
+              <div>
+                {{ selectedPatient.emergency_contact_name || '—' }}
+                <span v-if="selectedPatient.emergency_contact_phone">
+                  ({{ selectedPatient.emergency_contact_phone }})
                 </span>
-              </button>
-              <div v-if="expandedProperties.has(prop.property_id)" class="accordion-body">
-                <div class="note-editor">
-                  <label class="note-label" :for="`note-title-${prop.property_id}`">Title</label>
-                  <input
-                    :id="`note-title-${prop.property_id}`"
-                    class="note-title-input"
-                    :value="getPropertyDraft(prop).name"
-                    @input="onPropertyFieldChange(prop, 'name', ($event.target as HTMLInputElement).value)"
-                  />
-                  <label class="note-label" :for="`note-body-${prop.property_id}`">Notes</label>
-                  <textarea
-                    :id="`note-body-${prop.property_id}`"
-                    class="note-body-input"
-                    rows="5"
-                    :value="getPropertyDraft(prop).description"
-                    @input="onPropertyFieldChange(prop, 'description', ($event.target as HTMLTextAreaElement).value)"
-                  />
-                  <p class="note-audit">
-                    Created by Dr. {{ formatProviderName(prop.created_by_name) }}
-                    · Last edited by Dr. {{ formatProviderName(prop.updated_by_name) }}
-                    <span v-if="prop.updated_at"> · {{ formatDate(prop.updated_at) }}</span>
-                  </p>
+              </div>
+            </div>
+            <div class="detail-card" v-if="selectedPatient.portal_email">
+              <p class="detail-label">Portal Email</p>
+              <div>{{ selectedPatient.portal_email }}</div>
+            </div>
+          </div>
+
+          <div class="properties-section">
+            <div class="properties-header">
+              <h3>Notes</h3>
+              <button class="add-btn" @click="openAddProperty">+ Add</button>
+            </div>
+
+            <div v-if="propertiesLoading" class="state">Loading properties...</div>
+            <div v-else-if="propertiesError" class="state error">{{ propertiesError }}</div>
+            <div v-else-if="patientProperties.length === 0" class="state">No properties yet.</div>
+
+            <div class="accordion" v-else>
+              <div
+                v-for="prop in patientProperties"
+                :key="prop.property_id"
+                class="accordion-item"
+              >
+                <button class="accordion-header" @click="toggleProperty(prop.property_id)">
+                  <span>{{ getPropertyDisplayName(prop) }}</span>
+                  <span class="accordion-actions">
+                    <span v-if="getSaveStatus(prop.property_id) !== 'idle'" class="note-save-status-inline" :class="getSaveStatus(prop.property_id)">
+                      {{ saveStatusLabel(prop.property_id) }}
+                    </span>
+                    <span class="toggle-indicator">
+                      {{ expandedProperties.has(prop.property_id) ? '−' : '+' }}
+                    </span>
+                    <button class="delete-btn" @click.stop="confirmDelete(prop)">Delete</button>
+                  </span>
+                </button>
+                <div v-if="expandedProperties.has(prop.property_id)" class="accordion-body">
+                  <div class="note-editor">
+                    <label class="note-label" :for="`note-title-${prop.property_id}`">Title</label>
+                    <input
+                      :id="`note-title-${prop.property_id}`"
+                      class="note-title-input"
+                      :value="getPropertyDraft(prop).name"
+                      @input="onPropertyFieldChange(prop, 'name', ($event.target as HTMLInputElement).value)"
+                    />
+                    <label class="note-label" :for="`note-body-${prop.property_id}`">Notes</label>
+                    <textarea
+                      :id="`note-body-${prop.property_id}`"
+                      class="note-body-input"
+                      rows="5"
+                      :value="getPropertyDraft(prop).description"
+                      @input="onPropertyFieldChange(prop, 'description', ($event.target as HTMLTextAreaElement).value)"
+                    />
+                    <p class="note-audit">
+                      Created by Dr. {{ formatProviderName(prop.created_by_name) }}
+                      · Last edited by Dr. {{ formatProviderName(prop.updated_by_name) }}
+                      <span v-if="prop.updated_at"> · {{ formatDate(prop.updated_at) }}</span>
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        <!-- Documents Section -->
-        <div class="documents-section">
+        <div v-else-if="activeChartTab === 'allergies'" class="chart-panel">
+          <div class="section-header">
+            <h3>Allergies</h3>
+            <button class="add-btn" @click="openAllergyModal()">+ Add</button>
+          </div>
+          <div v-if="allergiesLoading" class="state">Loading allergies...</div>
+          <div v-else-if="allergiesError" class="state error">{{ allergiesError }}</div>
+          <div v-else-if="allergies.length === 0" class="state">No allergies recorded.</div>
+          <div v-else class="chart-table-wrap">
+            <table class="chart-table">
+              <thead>
+                <tr>
+                  <th>Allergen</th>
+                  <th>Reaction</th>
+                  <th>Severity</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in allergies" :key="item.id">
+                  <td>{{ item.allergen }}</td>
+                  <td>{{ item.reaction || '—' }}</td>
+                  <td>{{ item.severity }}</td>
+                  <td><span class="status-pill" :class="item.status">{{ item.status }}</span></td>
+                  <td class="row-actions">
+                    <button class="icon-btn" @click="openAllergyModal(item)" title="Edit">✏️</button>
+                    <button class="icon-btn delete-btn-icon" @click="confirmDeleteAllergy(item)" title="Delete">🗑️</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div v-else-if="activeChartTab === 'medications'" class="chart-panel">
+          <div class="section-header">
+            <h3>Medications</h3>
+            <button class="add-btn" @click="openMedicationModal()">+ Add</button>
+          </div>
+          <div v-if="medicationsLoading" class="state">Loading medications...</div>
+          <div v-else-if="medicationsError" class="state error">{{ medicationsError }}</div>
+          <div v-else-if="medications.length === 0" class="state">No medications recorded.</div>
+          <div v-else class="chart-table-wrap">
+            <table class="chart-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Dosage</th>
+                  <th>Frequency</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in medications" :key="item.id">
+                  <td>{{ item.name }}</td>
+                  <td>{{ item.dosage || '—' }}</td>
+                  <td>{{ item.frequency || '—' }}</td>
+                  <td><span class="status-pill" :class="item.status">{{ item.status }}</span></td>
+                  <td class="row-actions">
+                    <button class="icon-btn" @click="openMedicationModal(item)" title="Edit">✏️</button>
+                    <button class="icon-btn delete-btn-icon" @click="confirmDeleteMedication(item)" title="Delete">🗑️</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div v-else-if="activeChartTab === 'problems'" class="chart-panel">
+          <div class="section-header">
+            <h3>Problems</h3>
+            <button class="add-btn" @click="openProblemModal()">+ Add</button>
+          </div>
+          <div v-if="problemsLoading" class="state">Loading problems...</div>
+          <div v-else-if="problemsError" class="state error">{{ problemsError }}</div>
+          <div v-else-if="problems.length === 0" class="state">No problems recorded.</div>
+          <div v-else class="chart-table-wrap">
+            <table class="chart-table">
+              <thead>
+                <tr>
+                  <th>Problem</th>
+                  <th>Onset</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in problems" :key="item.id">
+                  <td>{{ item.name }}</td>
+                  <td>{{ item.onset_date ? formatDate(item.onset_date) : '—' }}</td>
+                  <td><span class="status-pill" :class="item.status">{{ item.status }}</span></td>
+                  <td class="row-actions">
+                    <button class="icon-btn" @click="openProblemModal(item)" title="Edit">✏️</button>
+                    <button class="icon-btn delete-btn-icon" @click="confirmDeleteProblem(item)" title="Delete">🗑️</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div v-else-if="activeChartTab === 'documents'" class="chart-panel">
           <div class="documents-header">
             <h3>Documents</h3>
-            <button class="add-btn" @click="triggerFileUpload">+ Upload</button>
-            <input
-              ref="fileInput"
-              type="file"
-              multiple
-              style="display: none"
-              @change="handleFileUpload"
-            />
+            <div class="documents-header-actions">
+              <label class="visibility-checkbox">
+                <input v-model="uploadPatientVisible" type="checkbox" />
+                Visible to patient
+              </label>
+              <button class="add-btn" @click="triggerFileUpload">+ Upload</button>
+              <input
+                ref="fileInput"
+                type="file"
+                multiple
+                style="display: none"
+                @change="handleFileUpload"
+              />
+            </div>
           </div>
 
           <div v-if="documentsLoading" class="state">Loading documents...</div>
@@ -154,8 +319,18 @@
                   {{ doc.title }}
                 </a>
                 <span class="document-size">{{ formatFileSize(doc.file_size) }}</span>
+                <span class="visibility-badge" :class="{ visible: doc.patient_visible }">
+                  {{ doc.patient_visible ? 'Patient visible' : 'Provider only' }}
+                </span>
               </div>
               <div class="document-actions">
+                <button
+                  class="icon-btn"
+                  :title="doc.patient_visible ? 'Hide from patient' : 'Share with patient'"
+                  @click="toggleDocumentVisibility(doc)"
+                >
+                  {{ doc.patient_visible ? '🔒' : '🔓' }}
+                </button>
                 <button class="icon-btn rename-btn" @click="openRenameDialog(doc)" title="Rename">
                   ✏️
                 </button>
@@ -170,11 +345,8 @@
             <span>Uploading...</span>
           </div>
         </div>
-
-        <div class="detail-note">
-          Future enhancement: editable patient details and clinical history.
-        </div>
       </section>
+
     </div>
 
     <!-- Add Patient Modal -->
@@ -306,14 +478,206 @@
         </div>
       </div>
     </div>
+
+    <!-- Allergy Modal -->
+    <div v-if="showAllergyModal" class="modal-overlay" @click="closeAllergyModal">
+      <div class="modal" @click.stop>
+        <div class="modal-header">
+          <h2>{{ editingAllergyId ? 'Edit Allergy' : 'Add Allergy' }}</h2>
+          <button class="close-btn" @click="closeAllergyModal">✕</button>
+        </div>
+        <div class="modal-content">
+          <div v-if="allergyFormError" class="error-banner">{{ allergyFormError }}</div>
+          <div class="form-group">
+            <label>Allergen *</label>
+            <input v-model="allergyForm.allergen" type="text" placeholder="e.g. Penicillin" />
+          </div>
+          <div class="form-group">
+            <label>Reaction</label>
+            <input v-model="allergyForm.reaction" type="text" placeholder="e.g. Rash" />
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Severity</label>
+              <select v-model="allergyForm.severity">
+                <option value="unknown">unknown</option>
+                <option value="mild">mild</option>
+                <option value="moderate">moderate</option>
+                <option value="severe">severe</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Status</label>
+              <select v-model="allergyForm.status">
+                <option value="active">active</option>
+                <option value="inactive">inactive</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label>Notes</label>
+            <textarea v-model="allergyForm.notes" rows="3"></textarea>
+          </div>
+        </div>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="closeAllergyModal">Cancel</button>
+          <button class="btn-primary" :disabled="allergySaving" @click="saveAllergy">
+            {{ allergySaving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Medication Modal -->
+    <div v-if="showMedicationModal" class="modal-overlay" @click="closeMedicationModal">
+      <div class="modal" @click.stop>
+        <div class="modal-header">
+          <h2>{{ editingMedicationId ? 'Edit Medication' : 'Add Medication' }}</h2>
+          <button class="close-btn" @click="closeMedicationModal">✕</button>
+        </div>
+        <div class="modal-content">
+          <div v-if="medicationFormError" class="error-banner">{{ medicationFormError }}</div>
+          <div class="form-group">
+            <label>Name *</label>
+            <input v-model="medicationForm.name" type="text" placeholder="e.g. Lisinopril" />
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Dosage</label>
+              <input v-model="medicationForm.dosage" type="text" placeholder="10 mg" />
+            </div>
+            <div class="form-group">
+              <label>Frequency</label>
+              <input v-model="medicationForm.frequency" type="text" placeholder="Once daily" />
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Route</label>
+              <input v-model="medicationForm.route" type="text" placeholder="Oral" />
+            </div>
+            <div class="form-group">
+              <label>Status</label>
+              <select v-model="medicationForm.status">
+                <option value="active">active</option>
+                <option value="discontinued">discontinued</option>
+                <option value="completed">completed</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Start Date</label>
+              <input v-model="medicationForm.start_date" type="date" />
+            </div>
+            <div class="form-group">
+              <label>End Date</label>
+              <input v-model="medicationForm.end_date" type="date" />
+            </div>
+          </div>
+          <div class="form-group">
+            <label>Notes</label>
+            <textarea v-model="medicationForm.notes" rows="3"></textarea>
+          </div>
+        </div>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="closeMedicationModal">Cancel</button>
+          <button class="btn-primary" :disabled="medicationSaving" @click="saveMedication">
+            {{ medicationSaving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Problem Modal -->
+    <div v-if="showProblemModal" class="modal-overlay" @click="closeProblemModal">
+      <div class="modal" @click.stop>
+        <div class="modal-header">
+          <h2>{{ editingProblemId ? 'Edit Problem' : 'Add Problem' }}</h2>
+          <button class="close-btn" @click="closeProblemModal">✕</button>
+        </div>
+        <div class="modal-content">
+          <div v-if="problemFormError" class="error-banner">{{ problemFormError }}</div>
+          <div class="form-group">
+            <label>Problem *</label>
+            <input v-model="problemForm.name" type="text" placeholder="e.g. Hypertension" />
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label>Status</label>
+              <select v-model="problemForm.status">
+                <option value="active">active</option>
+                <option value="resolved">resolved</option>
+                <option value="inactive">inactive</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Onset Date</label>
+              <input v-model="problemForm.onset_date" type="date" />
+            </div>
+          </div>
+          <div class="form-group">
+            <label>Resolved Date</label>
+            <input v-model="problemForm.resolved_date" type="date" />
+          </div>
+          <div class="form-group">
+            <label>Notes</label>
+            <textarea v-model="problemForm.notes" rows="3"></textarea>
+          </div>
+        </div>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="closeProblemModal">Cancel</button>
+          <button class="btn-primary" :disabled="problemSaving" @click="saveProblem">
+            {{ problemSaving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showDeleteAllergyConfirm" class="modal-overlay" @click="showDeleteAllergyConfirm = false">
+      <div class="modal small" @click.stop>
+        <div class="modal-content">
+          <p>Delete allergy "{{ pendingDeleteAllergy?.allergen }}"?</p>
+          <div class="modal-actions">
+            <button class="btn-danger" @click="deleteAllergy">Delete</button>
+            <button class="btn-secondary" @click="showDeleteAllergyConfirm = false">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showDeleteMedicationConfirm" class="modal-overlay" @click="showDeleteMedicationConfirm = false">
+      <div class="modal small" @click.stop>
+        <div class="modal-content">
+          <p>Delete medication "{{ pendingDeleteMedication?.name }}"?</p>
+          <div class="modal-actions">
+            <button class="btn-danger" @click="deleteMedication">Delete</button>
+            <button class="btn-secondary" @click="showDeleteMedicationConfirm = false">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showDeleteProblemConfirm" class="modal-overlay" @click="showDeleteProblemConfirm = false">
+      <div class="modal small" @click.stop>
+        <div class="modal-content">
+          <p>Delete problem "{{ pendingDeleteProblem?.name }}"?</p>
+          <div class="modal-actions">
+            <button class="btn-danger" @click="deleteProblem">Delete</button>
+            <button class="btn-secondary" @click="showDeleteProblemConfirm = false">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import type { Patient, PatientProperty, PatientDocument } from '@/types'
-import { patientPropertiesApi } from '@/api/index'
+import type { Patient, PatientProperty, PatientDocument, Allergy, Medication, Problem, ChartSummary, AllergySeverity, AllergyStatus, MedicationStatus, ProblemStatus } from '@/types'
+import { patientPropertiesApi, chartApi, documentsApi } from '@/api/index'
 import { logout } from '@/store'
 
 const AUTOSAVE_DELAY_MS = 800
@@ -414,6 +778,75 @@ const renameForm = ref({
   id: '',
   title: ''
 })
+const uploadPatientVisible = ref(false)
+
+type ChartTabId = 'summary' | 'allergies' | 'medications' | 'problems' | 'documents'
+const chartTabs: { id: ChartTabId; label: string }[] = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'allergies', label: 'Allergies' },
+  { id: 'medications', label: 'Medications' },
+  { id: 'problems', label: 'Problems' },
+  { id: 'documents', label: 'Documents' },
+]
+const activeChartTab = ref<ChartTabId>('summary')
+
+const chartSummary = ref<ChartSummary | null>(null)
+const summaryLoading = ref(false)
+const summaryError = ref('')
+
+const allergies = ref<Allergy[]>([])
+const allergiesLoading = ref(false)
+const allergiesError = ref('')
+const showAllergyModal = ref(false)
+const allergySaving = ref(false)
+const allergyFormError = ref('')
+const editingAllergyId = ref<string | null>(null)
+const allergyForm = ref({
+  allergen: '',
+  reaction: '',
+  severity: 'unknown' as AllergySeverity,
+  status: 'active' as AllergyStatus,
+  notes: '',
+})
+const showDeleteAllergyConfirm = ref(false)
+const pendingDeleteAllergy = ref<Allergy | null>(null)
+
+const medications = ref<Medication[]>([])
+const medicationsLoading = ref(false)
+const medicationsError = ref('')
+const showMedicationModal = ref(false)
+const medicationSaving = ref(false)
+const medicationFormError = ref('')
+const editingMedicationId = ref<string | null>(null)
+const medicationForm = ref({
+  name: '',
+  dosage: '',
+  frequency: '',
+  route: '',
+  status: 'active' as MedicationStatus,
+  start_date: '',
+  end_date: '',
+  notes: '',
+})
+const showDeleteMedicationConfirm = ref(false)
+const pendingDeleteMedication = ref<Medication | null>(null)
+
+const problems = ref<Problem[]>([])
+const problemsLoading = ref(false)
+const problemsError = ref('')
+const showProblemModal = ref(false)
+const problemSaving = ref(false)
+const problemFormError = ref('')
+const editingProblemId = ref<string | null>(null)
+const problemForm = ref({
+  name: '',
+  status: 'active' as ProblemStatus,
+  onset_date: '',
+  resolved_date: '',
+  notes: '',
+})
+const showDeleteProblemConfirm = ref(false)
+const pendingDeleteProblem = ref<Problem | null>(null)
 
 const selectedPatient = computed(() =>
   patients.value.find(p => p.id === selectedPatientId.value) || null
@@ -809,8 +1242,22 @@ onBeforeUnmount(() => {
 
 watch(selectedPatientId, () => {
   clearPendingSaves()
+  activeChartTab.value = 'summary'
   loadProperties()
   loadDocuments()
+  loadChartSummary()
+  loadAllergies()
+  loadMedications()
+  loadProblems()
+})
+
+watch(activeChartTab, (tab) => {
+  if (!selectedPatientId.value) return
+  if (tab === 'summary') loadChartSummary()
+  if (tab === 'allergies') loadAllergies()
+  if (tab === 'medications') loadMedications()
+  if (tab === 'problems') loadProblems()
+  if (tab === 'documents') loadDocuments()
 })
 
 // Document functions
@@ -866,6 +1313,7 @@ async function handleFileUpload(event: Event) {
     for (const file of Array.from(files)) {
       formData.append('files', file)
     }
+    formData.append('patient_visible', uploadPatientVisible.value ? 'true' : 'false')
     
     const response = await fetch(`/api/documents/${selectedPatientId.value}`, {
       method: 'POST',
@@ -1025,6 +1473,347 @@ function formatFileSize(bytes: number): string {
     i++
   }
   return `${bytes.toFixed(1)} ${units[i]}`
+}
+
+async function loadChartSummary() {
+  if (!selectedPatientId.value) {
+    chartSummary.value = null
+    return
+  }
+  summaryLoading.value = true
+  summaryError.value = ''
+  try {
+    const result = await chartApi.getSummary(selectedPatientId.value)
+    if (result.error) {
+      summaryError.value = result.error
+      return
+    }
+    chartSummary.value = result.data?.summary || null
+  } catch (err) {
+    console.error('Failed to load chart summary:', err)
+    summaryError.value = 'Failed to load chart summary'
+  } finally {
+    summaryLoading.value = false
+  }
+}
+
+async function loadAllergies() {
+  if (!selectedPatientId.value) {
+    allergies.value = []
+    return
+  }
+  allergiesLoading.value = true
+  allergiesError.value = ''
+  try {
+    const result = await chartApi.listAllergies(selectedPatientId.value)
+    if (result.error) {
+      allergiesError.value = result.error
+      return
+    }
+    allergies.value = result.data?.allergies || []
+  } catch (err) {
+    console.error('Failed to load allergies:', err)
+    allergiesError.value = 'Failed to load allergies'
+  } finally {
+    allergiesLoading.value = false
+  }
+}
+
+function openAllergyModal(item?: Allergy) {
+  allergyFormError.value = ''
+  if (item) {
+    editingAllergyId.value = item.id
+    allergyForm.value = {
+      allergen: item.allergen,
+      reaction: item.reaction || '',
+      severity: item.severity,
+      status: item.status,
+      notes: item.notes || '',
+    }
+  } else {
+    editingAllergyId.value = null
+    allergyForm.value = {
+      allergen: '',
+      reaction: '',
+      severity: 'unknown',
+      status: 'active',
+      notes: '',
+    }
+  }
+  showAllergyModal.value = true
+}
+
+function closeAllergyModal() {
+  showAllergyModal.value = false
+  allergyFormError.value = ''
+}
+
+async function saveAllergy() {
+  if (!selectedPatientId.value) return
+  if (!allergyForm.value.allergen.trim()) {
+    allergyFormError.value = 'Allergen is required.'
+    return
+  }
+  allergySaving.value = true
+  allergyFormError.value = ''
+  try {
+    const payload = {
+      allergen: allergyForm.value.allergen.trim(),
+      reaction: allergyForm.value.reaction,
+      severity: allergyForm.value.severity,
+      status: allergyForm.value.status,
+      notes: allergyForm.value.notes,
+    }
+    const result = editingAllergyId.value
+      ? await chartApi.updateAllergy(selectedPatientId.value, editingAllergyId.value, payload)
+      : await chartApi.createAllergy(selectedPatientId.value, payload)
+    if (result.error) {
+      allergyFormError.value = result.error
+      return
+    }
+    closeAllergyModal()
+    await Promise.all([loadAllergies(), loadChartSummary()])
+  } finally {
+    allergySaving.value = false
+  }
+}
+
+function confirmDeleteAllergy(item: Allergy) {
+  pendingDeleteAllergy.value = item
+  showDeleteAllergyConfirm.value = true
+}
+
+async function deleteAllergy() {
+  if (!selectedPatientId.value || !pendingDeleteAllergy.value) return
+  const result = await chartApi.deleteAllergy(selectedPatientId.value, pendingDeleteAllergy.value.id)
+  if (result.error) {
+    allergiesError.value = result.error
+  } else {
+    showDeleteAllergyConfirm.value = false
+    pendingDeleteAllergy.value = null
+    await Promise.all([loadAllergies(), loadChartSummary()])
+  }
+}
+
+async function loadMedications() {
+  if (!selectedPatientId.value) {
+    medications.value = []
+    return
+  }
+  medicationsLoading.value = true
+  medicationsError.value = ''
+  try {
+    const result = await chartApi.listMedications(selectedPatientId.value)
+    if (result.error) {
+      medicationsError.value = result.error
+      return
+    }
+    medications.value = result.data?.medications || []
+  } catch (err) {
+    console.error('Failed to load medications:', err)
+    medicationsError.value = 'Failed to load medications'
+  } finally {
+    medicationsLoading.value = false
+  }
+}
+
+function openMedicationModal(item?: Medication) {
+  medicationFormError.value = ''
+  if (item) {
+    editingMedicationId.value = item.id
+    medicationForm.value = {
+      name: item.name,
+      dosage: item.dosage || '',
+      frequency: item.frequency || '',
+      route: item.route || '',
+      status: item.status,
+      start_date: item.start_date ? String(item.start_date).slice(0, 10) : '',
+      end_date: item.end_date ? String(item.end_date).slice(0, 10) : '',
+      notes: item.notes || '',
+    }
+  } else {
+    editingMedicationId.value = null
+    medicationForm.value = {
+      name: '',
+      dosage: '',
+      frequency: '',
+      route: '',
+      status: 'active',
+      start_date: '',
+      end_date: '',
+      notes: '',
+    }
+  }
+  showMedicationModal.value = true
+}
+
+function closeMedicationModal() {
+  showMedicationModal.value = false
+  medicationFormError.value = ''
+}
+
+async function saveMedication() {
+  if (!selectedPatientId.value) return
+  if (!medicationForm.value.name.trim()) {
+    medicationFormError.value = 'Name is required.'
+    return
+  }
+  medicationSaving.value = true
+  medicationFormError.value = ''
+  try {
+    const payload = {
+      name: medicationForm.value.name.trim(),
+      dosage: medicationForm.value.dosage,
+      frequency: medicationForm.value.frequency,
+      route: medicationForm.value.route,
+      status: medicationForm.value.status,
+      start_date: medicationForm.value.start_date || null,
+      end_date: medicationForm.value.end_date || null,
+      notes: medicationForm.value.notes,
+    }
+    const result = editingMedicationId.value
+      ? await chartApi.updateMedication(selectedPatientId.value, editingMedicationId.value, payload)
+      : await chartApi.createMedication(selectedPatientId.value, payload)
+    if (result.error) {
+      medicationFormError.value = result.error
+      return
+    }
+    closeMedicationModal()
+    await Promise.all([loadMedications(), loadChartSummary()])
+  } finally {
+    medicationSaving.value = false
+  }
+}
+
+function confirmDeleteMedication(item: Medication) {
+  pendingDeleteMedication.value = item
+  showDeleteMedicationConfirm.value = true
+}
+
+async function deleteMedication() {
+  if (!selectedPatientId.value || !pendingDeleteMedication.value) return
+  const result = await chartApi.deleteMedication(selectedPatientId.value, pendingDeleteMedication.value.id)
+  if (result.error) {
+    medicationsError.value = result.error
+  } else {
+    showDeleteMedicationConfirm.value = false
+    pendingDeleteMedication.value = null
+    await Promise.all([loadMedications(), loadChartSummary()])
+  }
+}
+
+async function loadProblems() {
+  if (!selectedPatientId.value) {
+    problems.value = []
+    return
+  }
+  problemsLoading.value = true
+  problemsError.value = ''
+  try {
+    const result = await chartApi.listProblems(selectedPatientId.value)
+    if (result.error) {
+      problemsError.value = result.error
+      return
+    }
+    problems.value = result.data?.problems || []
+  } catch (err) {
+    console.error('Failed to load problems:', err)
+    problemsError.value = 'Failed to load problems'
+  } finally {
+    problemsLoading.value = false
+  }
+}
+
+function openProblemModal(item?: Problem) {
+  problemFormError.value = ''
+  if (item) {
+    editingProblemId.value = item.id
+    problemForm.value = {
+      name: item.name,
+      status: item.status,
+      onset_date: item.onset_date ? String(item.onset_date).slice(0, 10) : '',
+      resolved_date: item.resolved_date ? String(item.resolved_date).slice(0, 10) : '',
+      notes: item.notes || '',
+    }
+  } else {
+    editingProblemId.value = null
+    problemForm.value = {
+      name: '',
+      status: 'active',
+      onset_date: '',
+      resolved_date: '',
+      notes: '',
+    }
+  }
+  showProblemModal.value = true
+}
+
+function closeProblemModal() {
+  showProblemModal.value = false
+  problemFormError.value = ''
+}
+
+async function saveProblem() {
+  if (!selectedPatientId.value) return
+  if (!problemForm.value.name.trim()) {
+    problemFormError.value = 'Problem name is required.'
+    return
+  }
+  problemSaving.value = true
+  problemFormError.value = ''
+  try {
+    const payload = {
+      name: problemForm.value.name.trim(),
+      status: problemForm.value.status,
+      onset_date: problemForm.value.onset_date || null,
+      resolved_date: problemForm.value.resolved_date || null,
+      notes: problemForm.value.notes,
+    }
+    const result = editingProblemId.value
+      ? await chartApi.updateProblem(selectedPatientId.value, editingProblemId.value, payload)
+      : await chartApi.createProblem(selectedPatientId.value, payload)
+    if (result.error) {
+      problemFormError.value = result.error
+      return
+    }
+    closeProblemModal()
+    await Promise.all([loadProblems(), loadChartSummary()])
+  } finally {
+    problemSaving.value = false
+  }
+}
+
+function confirmDeleteProblem(item: Problem) {
+  pendingDeleteProblem.value = item
+  showDeleteProblemConfirm.value = true
+}
+
+async function deleteProblem() {
+  if (!selectedPatientId.value || !pendingDeleteProblem.value) return
+  const result = await chartApi.deleteProblem(selectedPatientId.value, pendingDeleteProblem.value.id)
+  if (result.error) {
+    problemsError.value = result.error
+  } else {
+    showDeleteProblemConfirm.value = false
+    pendingDeleteProblem.value = null
+    await Promise.all([loadProblems(), loadChartSummary()])
+  }
+}
+
+async function toggleDocumentVisibility(doc: PatientDocument) {
+  const result = await documentsApi.setVisibility(doc.id, !doc.patient_visible)
+  if (result.error) {
+    documentsError.value = result.error
+    return
+  }
+  if (result.data?.document) {
+    const idx = documents.value.findIndex(d => d.id === doc.id)
+    if (idx !== -1) {
+      const next = [...documents.value]
+      next[idx] = result.data.document
+      documents.value = next
+    }
+  }
 }
 </script>
 
@@ -1192,46 +1981,47 @@ function formatFileSize(bytes: number): string {
   color: #4338ca;
   border-radius: 6px;
   padding: 0.4rem 0.8rem;
-
-  .add-patient-btn {
-    display: block;
-    width: calc(100% - 2rem);
-    margin: 0.75rem 1rem 0;
-    padding: 0.55rem 1rem;
-    background: #4f46e5;
-    color: #fff;
-    border: none;
-    border-radius: 8px;
-    font-weight: 600;
-    font-size: 0.9rem;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  .add-patient-btn:hover {
-    background: #4338ca;
-  }
-
-  .error-banner {
-    background: #fef2f2;
-    border: 1px solid #fca5a5;
-    color: #b91c1c;
-    border-radius: 6px;
-    padding: 0.75rem 1rem;
-    margin-bottom: 1rem;
-    font-size: 0.9rem;
-  }
-
-  .success-banner {
-    background: #f0fdf4;
-    border: 1px solid #86efac;
-    color: #166534;
-    border-radius: 6px;
-    padding: 0.75rem 1rem;
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
   font-weight: 600;
   cursor: pointer;
+}
+
+.add-patient-btn {
+  display: block;
+  width: calc(100% - 2rem);
+  margin: 0.75rem 1rem 0;
+  padding: 0.55rem 1rem;
+  background: #4f46e5;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.add-patient-btn:hover {
+  background: #4338ca;
+}
+
+.error-banner {
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  color: #b91c1c;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.success-banner {
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  color: #166534;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
 }
 
 .accordion {
@@ -1541,8 +2331,201 @@ function formatFileSize(bytes: number): string {
   text-align: center;
 }
 
+.banner-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.chart-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 1.25rem;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 0.5rem;
+}
+
+.chart-tab {
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  padding: 0.45rem 0.85rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.chart-tab:hover {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.chart-tab.active {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
+.chart-panel {
+  min-height: 200px;
+}
+
+.summary-widgets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.summary-widget {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+}
+
+.summary-widget h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.summary-widget ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #374151;
+  font-size: 0.9rem;
+}
+
+.widget-empty {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.severity {
+  color: #6b7280;
+  text-transform: capitalize;
+}
+
+.demographics-grid {
+  margin-top: 0.5rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-header h3 {
+  margin: 0;
+}
+
+.chart-table-wrap {
+  overflow-x: auto;
+}
+
+.chart-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.chart-table th,
+.chart-table td {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.chart-table th {
+  color: #6b7280;
+  font-weight: 600;
+  background: #f9fafb;
+}
+
+.row-actions {
+  white-space: nowrap;
+  text-align: right;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.status-pill.active {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.status-pill.inactive,
+.status-pill.discontinued,
+.status-pill.resolved,
+.status-pill.completed {
+  background: #e5e7eb;
+  color: #4b5563;
+}
+
+.documents-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.visibility-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.visibility-badge {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+.visibility-badge.visible {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.form-group select {
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+  background: #fff;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
 @media (max-width: 900px) {
   .content.split {
+    grid-template-columns: 1fr;
+  }
+
+  .form-row {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a provider-only patient chart to the existing Patients view with **Summary**, **Allergies**, **Medications**, **Problems**, and **Documents** tabs.

- New structured CRUD tables/APIs for allergies, medications, and problems (`/api/chart/...`)
- Summary widgets show active allergies, current medications, and active problems; existing clinical notes remain on Summary
- Documents default to provider-only via `patient_visible`; providers can opt in on upload or toggle later
- Patient portal only lists/downloads documents marked visible

## Test plan
- [x] `pytest api/tests/test_chart.py` (CRUD, doctor-only auth, document visibility gating)
- [ ] Log in as `doctor1` → Patients → open a patient → verify chart tabs and CRUD
- [ ] Upload a document with/without “Visible to patient”; confirm toggle works
- [ ] Log in as `patient1` → Documents tab only shows shared documents
- [ ] Confirm provider-only docs return 403 on patient download
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86a0e387-e49c-49d6-ad92-6b28d46c4a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86a0e387-e49c-49d6-ad92-6b28d46c4a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

