### PR TITLE
Add kiosk check-in profile photo capture

### DIFF
--- a/api/routes/appointments.py
+++ b/api/routes/appointments.py
@@ -87,6 +87,7 @@ def kiosk_lookup():
         # Find their next upcoming appointment
         apt_query = """
             SELECT a.id,
+                   a.patient_id,
                    a.appointment_date,
                    a.reason,
                    a.status,

--- a/api/routes/documents.py
+++ b/api/routes/documents.py
@@ -212,7 +212,9 @@ def list_documents(patient_id):
             query = f"""
                 SELECT {DOCUMENT_COLUMNS}
                 FROM medical_documents
-                WHERE patient_id = %s AND patient_visible = TRUE
+                WHERE patient_id = %s
+                  AND patient_visible = TRUE
+                  AND document_type <> 'profile_photo'
                 ORDER BY created_at DESC
             """
         elif user.get('role') == 'doctor':
@@ -220,6 +222,7 @@ def list_documents(patient_id):
                 SELECT {DOCUMENT_COLUMNS}
                 FROM medical_documents
                 WHERE patient_id = %s
+                  AND document_type <> 'profile_photo'
                 ORDER BY created_at DESC
             """
         else:

--- a/api/routes/patients.py
+++ b/api/routes/patients.py
@@ -5,12 +5,16 @@ Provides patient record access for providers; allows providers to create patient
 
 from flask import Blueprint, request, jsonify, current_app, send_file
 from datetime import date, datetime
+from io import BytesIO
+import os
+from werkzeug.datastructures import FileStorage
 from api.db.connection import execute_query
 from api.middleware.auth import authenticate
 import secrets
 import string
 import bcrypt
 from api.db.connection import DatabaseTransaction
+from api.utils.audit_log import log_data_access, log_audit_event, get_client_ip
 from api.routes.documents import (
     _save_file_to_storage,
     _download_file_from_storage,
@@ -23,6 +27,8 @@ INSUFFICIENT_PERMISSIONS_ERROR = 'Insufficient permissions'
 PATIENT_NOT_FOUND_ERROR = 'Patient not found'
 PROFILE_PHOTO_NOT_FOUND_ERROR = 'Profile photo not found'
 PROFILE_PHOTO_TYPE = 'profile_photo'
+MAX_KIOSK_PHOTO_BYTES = 2 * 1024 * 1024  # webcam JPEGs are typically well under 2MB
+JPEG_MAGIC = b'\xff\xd8\xff'
 
 PATIENT_SELECT_COLUMNS = """
     p.id, p.user_id, p.first_name, p.last_name, p.date_of_birth,
@@ -90,6 +96,36 @@ def _patient_accessible_by_user(patient_id: str, user: dict) -> bool:
         fetch_one=True,
     )
     return bool(patient)
+
+
+def _validate_kiosk_jpeg(file) -> FileStorage:
+    """
+    Read the upload, enforce a tight size cap, and require JPEG magic bytes.
+    Returns a fresh FileStorage ready for document storage helpers.
+    """
+    stream = file.stream
+    stream.seek(0, os.SEEK_END)
+    size = stream.tell()
+    stream.seek(0)
+
+    if size <= 0:
+        raise ValueError('Photo file is empty')
+    if size > MAX_KIOSK_PHOTO_BYTES:
+        raise ValueError('Photo exceeds the 2MB kiosk upload limit')
+
+    payload = stream.read()
+    if not payload.startswith(JPEG_MAGIC):
+        raise ValueError('Photo must be a JPEG image')
+
+    content_type = (file.content_type or '').lower()
+    if content_type and content_type not in ('image/jpeg', 'image/jpg', 'application/octet-stream'):
+        raise ValueError('Photo must be a JPEG image')
+
+    return FileStorage(
+        stream=BytesIO(payload),
+        filename='profile-photo.jpg',
+        content_type='image/jpeg',
+    )
 
 
 @patients_bp.route('/doctors', methods=['GET'])
@@ -253,6 +289,7 @@ def upload_profile_photo_kiosk(patient_id):
     No auth — gated by patient_name + date_of_birth matching the patient.
     Accepts multipart JPEG from the kiosk camera step.
     """
+    stored_path = None
     try:
         patient_name = (request.form.get('patient_name') or '').strip()
         dob = (request.form.get('date_of_birth') or '').strip()
@@ -267,8 +304,13 @@ def upload_profile_photo_kiosk(patient_id):
         if not file or not file.filename:
             return jsonify({'error': 'Photo file is required'}), 400
 
+        try:
+            jpeg_file = _validate_kiosk_jpeg(file)
+        except ValueError as exc:
+            return jsonify({'error': str(exc)}), 400
+
         original_name = 'profile-photo.jpg'
-        stored_path, file_size = _save_file_to_storage(file, original_name)
+        stored_path, file_size = _save_file_to_storage(jpeg_file, original_name)
 
         old_doc_id = patient.get('profile_photo_document_id')
         old_file_path = None
@@ -281,45 +323,61 @@ def upload_profile_photo_kiosk(patient_id):
             if old_doc:
                 old_file_path = old_doc.get('file_path')
 
-        insert_query = f"""
-            INSERT INTO medical_documents
-            (patient_id, doctor_id, document_type, title, file_path, file_name,
-             file_size, document_date, patient_visible)
-            VALUES (%s, NULL, %s, %s, %s, %s, %s, CURRENT_DATE, TRUE)
-            RETURNING {DOCUMENT_COLUMNS}
-        """
-        new_doc = execute_query(
-            insert_query,
-            (
-                patient_id,
-                PROFILE_PHOTO_TYPE,
-                'Profile Photo',
-                stored_path,
-                original_name,
-                file_size,
-            ),
-            fetch_one=True,
-        )
-
-        execute_query(
-            """
-            UPDATE patients
-            SET profile_photo_document_id = %s, updated_at = NOW()
-            WHERE id = %s
-            """,
-            (new_doc['id'], patient_id),
-        )
-
-        if old_doc_id:
-            execute_query(
-                "DELETE FROM medical_documents WHERE id = %s",
-                (old_doc_id,),
+        with DatabaseTransaction() as cursor:
+            cursor.execute(
+                f"""
+                INSERT INTO medical_documents
+                (patient_id, doctor_id, document_type, title, file_path, file_name,
+                 file_size, document_date, patient_visible)
+                VALUES (%s, NULL, %s, %s, %s, %s, %s, CURRENT_DATE, TRUE)
+                RETURNING {DOCUMENT_COLUMNS}
+                """,
+                (
+                    patient_id,
+                    PROFILE_PHOTO_TYPE,
+                    'Profile Photo',
+                    stored_path,
+                    original_name,
+                    file_size,
+                ),
             )
-            if old_file_path:
-                try:
-                    _delete_file_from_storage(old_file_path)
-                except Exception:
-                    current_app.logger.exception('Failed to delete previous profile photo file')
+            new_doc = cursor.fetchone()
+
+            cursor.execute(
+                """
+                UPDATE patients
+                SET profile_photo_document_id = %s, updated_at = NOW()
+                WHERE id = %s
+                """,
+                (new_doc['id'], patient_id),
+            )
+
+            if old_doc_id:
+                cursor.execute(
+                    "DELETE FROM medical_documents WHERE id = %s",
+                    (old_doc_id,),
+                )
+
+        # Delete prior storage object only after DB commit
+        if old_file_path:
+            try:
+                _delete_file_from_storage(old_file_path)
+            except Exception:
+                current_app.logger.exception('Failed to delete previous profile photo file')
+
+        log_audit_event(
+            user_id=None,
+            action='DATA_CREATE',
+            table_name='profile_photo',
+            record_id=str(patient_id),
+            ip_address=get_client_ip(request),
+            user_agent=request.headers.get('User-Agent'),
+            details={
+                'source': 'kiosk',
+                'document_id': str(new_doc['id']),
+                'file_size': file_size,
+            },
+        )
 
         return jsonify({
             'has_profile_photo': True,
@@ -327,6 +385,11 @@ def upload_profile_photo_kiosk(patient_id):
         }), 201
 
     except Exception:
+        if stored_path:
+            try:
+                _delete_file_from_storage(stored_path)
+            except Exception:
+                current_app.logger.exception('Failed to clean up profile photo after error')
         current_app.logger.exception('Kiosk profile photo upload error')
         return jsonify({'error': 'Failed to upload profile photo'}), 500
 
@@ -362,6 +425,8 @@ def get_profile_photo(patient_id):
 
         memory_file, local_file_path = _download_file_from_storage(patient['file_path'])
         download_name = patient.get('file_name') or 'profile-photo.jpg'
+
+        log_data_access(user['id'], 'profile_photo', patient_id, 'VIEW', request)
 
         if memory_file:
             return send_file(

--- a/api/routes/patients.py
+++ b/api/routes/patients.py
@@ -3,7 +3,7 @@ Patients routes for HHS Patient Portal
 Provides patient record access for providers; allows providers to create patients
 """
 
-from flask import Blueprint, request, jsonify, current_app
+from flask import Blueprint, request, jsonify, current_app, send_file
 from datetime import date, datetime
 from api.db.connection import execute_query
 from api.middleware.auth import authenticate
@@ -11,9 +11,27 @@ import secrets
 import string
 import bcrypt
 from api.db.connection import DatabaseTransaction
+from api.routes.documents import (
+    _save_file_to_storage,
+    _download_file_from_storage,
+    _delete_file_from_storage,
+    DOCUMENT_COLUMNS,
+)
 
 patients_bp = Blueprint('patients', __name__, url_prefix='/api/patients')
 INSUFFICIENT_PERMISSIONS_ERROR = 'Insufficient permissions'
+PATIENT_NOT_FOUND_ERROR = 'Patient not found'
+PROFILE_PHOTO_NOT_FOUND_ERROR = 'Profile photo not found'
+PROFILE_PHOTO_TYPE = 'profile_photo'
+
+PATIENT_SELECT_COLUMNS = """
+    p.id, p.user_id, p.first_name, p.last_name, p.date_of_birth,
+    p.phone, p.address, p.emergency_contact_name,
+    p.emergency_contact_phone, p.created_at, p.updated_at,
+    p.profile_photo_document_id,
+    (p.profile_photo_document_id IS NOT NULL) AS has_profile_photo,
+    u.email AS portal_email
+"""
 
 
 def _generate_temp_password(length: int = 12) -> str:
@@ -34,6 +52,8 @@ def serialize_patient(patient):
     for key, value in result.items():
         if isinstance(value, (datetime, date)):
             result[key] = value.isoformat()
+    photo_doc_id = result.pop('profile_photo_document_id', None)
+    result['has_profile_photo'] = bool(photo_doc_id or result.get('has_profile_photo'))
     return result
 
 
@@ -45,6 +65,31 @@ def serialize_doctor(doctor):
         if isinstance(value, (datetime, date)):
             result[key] = value.isoformat()
     return result
+
+
+def _verify_patient_identity(patient_id: str, patient_name: str, dob: str):
+    """Match patient by id + full name + DOB (same rules as guest check-in)."""
+    query = """
+        SELECT id, first_name, last_name, date_of_birth, profile_photo_document_id
+        FROM patients
+        WHERE id = %s
+          AND LOWER(CONCAT(first_name, ' ', last_name)) = LOWER(%s)
+          AND date_of_birth = %s
+    """
+    return execute_query(query, (patient_id, patient_name.strip(), dob), fetch_one=True)
+
+
+def _patient_accessible_by_user(patient_id: str, user: dict) -> bool:
+    if user.get('role') == 'doctor':
+        return True
+    if user.get('role') != 'patient':
+        return False
+    patient = execute_query(
+        "SELECT id FROM patients WHERE id = %s AND user_id = %s",
+        (patient_id, user['id']),
+        fetch_one=True,
+    )
+    return bool(patient)
 
 
 @patients_bp.route('/doctors', methods=['GET'])
@@ -80,11 +125,8 @@ def get_my_patient_record():
         if user.get('role') != 'patient':
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
 
-        query = """
-            SELECT p.id, p.user_id, p.first_name, p.last_name, p.date_of_birth,
-                   p.phone, p.address, p.emergency_contact_name,
-                   p.emergency_contact_phone, p.created_at, p.updated_at,
-                   u.email AS portal_email
+        query = f"""
+            SELECT {PATIENT_SELECT_COLUMNS}
             FROM patients p
             LEFT JOIN users u ON p.user_id = u.id
             WHERE p.user_id = %s
@@ -109,11 +151,8 @@ def list_patients():
         if user.get('role') != 'doctor':
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
 
-        query = """
-            SELECT p.id, p.user_id, p.first_name, p.last_name, p.date_of_birth,
-                   p.phone, p.address, p.emergency_contact_name,
-                   p.emergency_contact_phone, p.created_at, p.updated_at,
-                   u.email AS portal_email
+        query = f"""
+            SELECT {PATIENT_SELECT_COLUMNS}
             FROM patients p
             LEFT JOIN users u ON p.user_id = u.id
             ORDER BY p.last_name, p.first_name
@@ -179,7 +218,7 @@ def create_patient():
                 INSERT INTO patients (user_id, first_name, last_name, date_of_birth, phone, address)
                 VALUES (%s, %s, %s, %s, %s, %s)
                 RETURNING id, user_id, first_name, last_name, date_of_birth, phone, address,
-                          created_at, updated_at
+                          profile_photo_document_id, created_at, updated_at
                 """,
                 (new_user['id'], first_name, last_name, date_of_birth, phone, address),
             )
@@ -205,3 +244,142 @@ def create_patient():
     except Exception:
         current_app.logger.exception('Provider create patient error')
         return jsonify({'error': 'Failed to create patient'}), 500
+
+
+@patients_bp.route('/<patient_id>/profile-photo/kiosk', methods=['POST'])
+def upload_profile_photo_kiosk(patient_id):
+    """
+    POST /api/patients/<patient_id>/profile-photo/kiosk
+    No auth — gated by patient_name + date_of_birth matching the patient.
+    Accepts multipart JPEG from the kiosk camera step.
+    """
+    try:
+        patient_name = (request.form.get('patient_name') or '').strip()
+        dob = (request.form.get('date_of_birth') or '').strip()
+        if not patient_name or not dob:
+            return jsonify({'error': 'patient_name and date_of_birth are required'}), 400
+
+        patient = _verify_patient_identity(patient_id, patient_name, dob)
+        if not patient:
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        file = request.files.get('file') or request.files.get('photo')
+        if not file or not file.filename:
+            return jsonify({'error': 'Photo file is required'}), 400
+
+        original_name = 'profile-photo.jpg'
+        stored_path, file_size = _save_file_to_storage(file, original_name)
+
+        old_doc_id = patient.get('profile_photo_document_id')
+        old_file_path = None
+        if old_doc_id:
+            old_doc = execute_query(
+                "SELECT id, file_path FROM medical_documents WHERE id = %s",
+                (old_doc_id,),
+                fetch_one=True,
+            )
+            if old_doc:
+                old_file_path = old_doc.get('file_path')
+
+        insert_query = f"""
+            INSERT INTO medical_documents
+            (patient_id, doctor_id, document_type, title, file_path, file_name,
+             file_size, document_date, patient_visible)
+            VALUES (%s, NULL, %s, %s, %s, %s, %s, CURRENT_DATE, TRUE)
+            RETURNING {DOCUMENT_COLUMNS}
+        """
+        new_doc = execute_query(
+            insert_query,
+            (
+                patient_id,
+                PROFILE_PHOTO_TYPE,
+                'Profile Photo',
+                stored_path,
+                original_name,
+                file_size,
+            ),
+            fetch_one=True,
+        )
+
+        execute_query(
+            """
+            UPDATE patients
+            SET profile_photo_document_id = %s, updated_at = NOW()
+            WHERE id = %s
+            """,
+            (new_doc['id'], patient_id),
+        )
+
+        if old_doc_id:
+            execute_query(
+                "DELETE FROM medical_documents WHERE id = %s",
+                (old_doc_id,),
+            )
+            if old_file_path:
+                try:
+                    _delete_file_from_storage(old_file_path)
+                except Exception:
+                    current_app.logger.exception('Failed to delete previous profile photo file')
+
+        return jsonify({
+            'has_profile_photo': True,
+            'document_id': str(new_doc['id']),
+        }), 201
+
+    except Exception:
+        current_app.logger.exception('Kiosk profile photo upload error')
+        return jsonify({'error': 'Failed to upload profile photo'}), 500
+
+
+@patients_bp.route('/<patient_id>/profile-photo', methods=['GET'])
+@authenticate
+def get_profile_photo(patient_id):
+    """
+    GET /api/patients/<patient_id>/profile-photo
+    Patient may fetch own photo; doctor may fetch any.
+    """
+    try:
+        user = request.user
+        if not _patient_accessible_by_user(patient_id, user):
+            return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
+
+        patient = execute_query(
+            """
+            SELECT p.id, p.profile_photo_document_id,
+                   d.file_path, d.file_name
+            FROM patients p
+            LEFT JOIN medical_documents d ON d.id = p.profile_photo_document_id
+            WHERE p.id = %s
+            """,
+            (patient_id,),
+            fetch_one=True,
+        )
+        if not patient:
+            return jsonify({'error': PATIENT_NOT_FOUND_ERROR}), 404
+
+        if not patient.get('profile_photo_document_id') or not patient.get('file_path'):
+            return jsonify({'error': PROFILE_PHOTO_NOT_FOUND_ERROR}), 404
+
+        memory_file, local_file_path = _download_file_from_storage(patient['file_path'])
+        download_name = patient.get('file_name') or 'profile-photo.jpg'
+
+        if memory_file:
+            return send_file(
+                memory_file,
+                mimetype='image/jpeg',
+                as_attachment=False,
+                download_name=download_name,
+            )
+        if local_file_path:
+            return send_file(
+                str(local_file_path),
+                mimetype='image/jpeg',
+                as_attachment=False,
+                download_name=download_name,
+            )
+
+        return jsonify({'error': PROFILE_PHOTO_NOT_FOUND_ERROR}), 404
+
+    except Exception:
+        current_app.logger.exception('Profile photo retrieval error')
+        return jsonify({'error': 'Failed to retrieve profile photo'}), 500

--- a/api/tests/test_profile_photo.py
+++ b/api/tests/test_profile_photo.py
@@ -1,0 +1,142 @@
+from io import BytesIO
+
+from api.db.connection import execute_query
+from api.tests.conftest import login_as, requires_db
+
+
+def _get_patient(username='patient1'):
+    patient = execute_query(
+        """
+        SELECT p.id, p.first_name, p.last_name, p.date_of_birth,
+               p.profile_photo_document_id
+        FROM patients p
+        JOIN users u ON u.id = p.user_id
+        WHERE u.username = %s
+        """,
+        (username,),
+        fetch_one=True,
+    )
+    assert patient is not None, f'Expected patient for {username}'
+    return patient
+
+
+def _jpeg_bytes():
+    # Minimal valid JPEG (1x1 pixel)
+    return BytesIO(
+        bytes([
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+            0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
+            0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
+            0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+            0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
+            0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
+            0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+            0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01,
+            0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x14, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x03, 0xFF, 0xC4, 0x00, 0x14, 0x10, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F, 0x00,
+            0x7F, 0xFF, 0xD9,
+        ])
+    )
+
+
+def _upload_kiosk_photo(client, patient, *, name=None, dob=None):
+    full_name = name if name is not None else f"{patient['first_name']} {patient['last_name']}"
+    date_of_birth = dob if dob is not None else str(patient['date_of_birth'])
+    data = {
+        'patient_name': full_name,
+        'date_of_birth': date_of_birth,
+        'file': (_jpeg_bytes(), 'profile-photo.jpg'),
+    }
+    return client.post(
+        f"/api/patients/{patient['id']}/profile-photo/kiosk",
+        data=data,
+        content_type='multipart/form-data',
+    )
+
+
+@requires_db
+def test_kiosk_profile_photo_upload_and_get(client):
+    patient = _get_patient('patient1')
+
+    upload = _upload_kiosk_photo(client, patient)
+    assert upload.status_code == 201, upload.get_json()
+    assert upload.get_json()['has_profile_photo'] is True
+
+    doctor_headers = login_as(client, 'doctor1')
+    doctor_get = client.get(
+        f"/api/patients/{patient['id']}/profile-photo",
+        headers=doctor_headers,
+    )
+    assert doctor_get.status_code == 200
+    assert doctor_get.content_type.startswith('image/')
+    assert len(doctor_get.data) > 0
+
+    patient_headers = login_as(client, 'patient1', 'Patient123!')
+    patient_get = client.get(
+        f"/api/patients/{patient['id']}/profile-photo",
+        headers=patient_headers,
+    )
+    assert patient_get.status_code == 200
+
+    me = client.get('/api/patients/me', headers=patient_headers)
+    assert me.status_code == 200
+    assert me.get_json()['patient']['has_profile_photo'] is True
+
+    list_res = client.get('/api/patients', headers=doctor_headers)
+    assert list_res.status_code == 200
+    listed = next(p for p in list_res.get_json()['patients'] if p['id'] == str(patient['id']) or p['id'] == patient['id'])
+    assert listed['has_profile_photo'] is True
+
+
+@requires_db
+def test_kiosk_profile_photo_rejects_identity_mismatch(client):
+    patient = _get_patient('patient1')
+    response = _upload_kiosk_photo(
+        client,
+        patient,
+        name='Wrong Name',
+        dob=str(patient['date_of_birth']),
+    )
+    assert response.status_code == 404
+
+
+@requires_db
+def test_profile_photo_excluded_from_document_list(client):
+    patient = _get_patient('patient1')
+    upload = _upload_kiosk_photo(client, patient)
+    assert upload.status_code == 201, upload.get_json()
+
+    doctor_headers = login_as(client, 'doctor1')
+    docs = client.get(f"/api/documents/{patient['id']}", headers=doctor_headers)
+    assert docs.status_code == 200, docs.get_json()
+    for doc in docs.get_json()['documents']:
+        assert doc['document_type'] != 'profile_photo'
+
+    # Ensure a profile_photo row exists in DB even though list excludes it
+    row = execute_query(
+        """
+        SELECT COUNT(*) AS count
+        FROM medical_documents
+        WHERE patient_id = %s AND document_type = 'profile_photo'
+        """,
+        (patient['id'],),
+        fetch_one=True,
+    )
+    assert row['count'] >= 1
+
+
+@requires_db
+def test_patient_cannot_get_other_patient_photo(client):
+    patient1 = _get_patient('patient1')
+    upload = _upload_kiosk_photo(client, patient1)
+    assert upload.status_code == 201, upload.get_json()
+
+    other_headers = login_as(client, 'patient2', 'Patient123!')
+    response = client.get(
+        f"/api/patients/{patient1['id']}/profile-photo",
+        headers=other_headers,
+    )
+    assert response.status_code == 403

--- a/api/tests/test_profile_photo.py
+++ b/api/tests/test_profile_photo.py
@@ -129,6 +129,23 @@ def test_profile_photo_excluded_from_document_list(client):
 
 
 @requires_db
+def test_kiosk_profile_photo_rejects_non_jpeg(client):
+    patient = _get_patient('patient1')
+    data = {
+        'patient_name': f"{patient['first_name']} {patient['last_name']}",
+        'date_of_birth': str(patient['date_of_birth']),
+        'file': (BytesIO(b'not-a-jpeg-payload'), 'profile-photo.jpg'),
+    }
+    response = client.post(
+        f"/api/patients/{patient['id']}/profile-photo/kiosk",
+        data=data,
+        content_type='multipart/form-data',
+    )
+    assert response.status_code == 400
+    assert 'JPEG' in (response.get_json() or {}).get('error', '')
+
+
+@requires_db
 def test_patient_cannot_get_other_patient_photo(client):
     patient1 = _get_patient('patient1')
     upload = _upload_kiosk_photo(client, patient1)

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -108,6 +108,12 @@ CREATE TABLE IF NOT EXISTS medical_documents (
 ALTER TABLE medical_documents
     ADD COLUMN IF NOT EXISTS patient_visible BOOLEAN NOT NULL DEFAULT FALSE;
 
+-- Profile photos are stored as medical_documents rows (document_type = 'profile_photo')
+-- and pointed to from patients; excluded from document list APIs.
+ALTER TABLE patients
+    ADD COLUMN IF NOT EXISTS profile_photo_document_id UUID
+        REFERENCES medical_documents(id) ON DELETE SET NULL;
+
 CREATE TABLE IF NOT EXISTS allergies (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     patient_id UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export interface Patient {
   emergency_contact_name?: string | null
   emergency_contact_phone?: string | null
   portal_email?: string | null
+  has_profile_photo?: boolean
   created_at?: string
   updated_at?: string
 }

--- a/src/views/KioskView.vue
+++ b/src/views/KioskView.vue
@@ -93,7 +93,7 @@
         </button>
       </div>
       <div v-else class="photo-actions">
-        <button type="button" class="kiosk-btn primary" :disabled="uploading" @click="usePhoto">
+        <button type="button" class="kiosk-btn primary" :disabled="uploading || !capturedBlob" @click="usePhoto">
           {{ uploading ? 'Saving…' : 'Use Photo' }}
         </button>
         <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="retakePhoto">
@@ -274,10 +274,10 @@ async function startFrontCamera(): Promise<boolean> {
     return false
   }
 
+  // Front-facing only — do not fall back to any/rear camera on dual-camera tablets
   const attempts: MediaStreamConstraints[] = [
     { video: { facingMode: { exact: 'user' } }, audio: false },
     { video: { facingMode: 'user' }, audio: false },
-    { video: true, audio: false },
   ]
 
   for (const constraints of attempts) {
@@ -292,7 +292,7 @@ async function startFrontCamera(): Promise<boolean> {
       cameraReady.value = true
       return true
     } catch {
-      // try next constraint
+      // try next front-facing constraint
     }
   }
   return false
@@ -343,7 +343,7 @@ async function handleLookup() {
   }
 }
 
-function takePhoto() {
+async function takePhoto() {
   const video = videoEl.value
   const canvas = canvasEl.value
   if (!video || !canvas || !cameraReady.value) return
@@ -358,14 +358,26 @@ function takePhoto() {
   // Draw un-mirrored frame (preview is CSS-mirrored only)
   ctx.drawImage(video, 0, 0, width, height)
 
-  capturedDataUrl.value = canvas.toDataURL('image/jpeg', 0.92)
-  canvas.toBlob(
-    (blob) => {
-      capturedBlob.value = blob
-    },
-    'image/jpeg',
-    0.92,
-  )
+  const dataUrl = canvas.toDataURL('image/jpeg', 0.92)
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((result) => resolve(result), 'image/jpeg', 0.92)
+  })
+
+  if (!blob) {
+    // Fallback: derive blob from data URL so Use Photo is never enabled without bytes
+    try {
+      const res = await fetch(dataUrl)
+      capturedBlob.value = await res.blob()
+      capturedDataUrl.value = dataUrl
+    } catch (e) {
+      console.error('Failed to capture photo blob:', e)
+      clearCapture()
+      return
+    }
+  } else {
+    capturedBlob.value = blob
+    capturedDataUrl.value = dataUrl
+  }
   resetInactivityTimer()
 }
 

--- a/src/views/KioskView.vue
+++ b/src/views/KioskView.vue
@@ -18,7 +18,7 @@
       <h2>Patient Check-In</h2>
       <p class="kiosk-instruction">Please enter your full name and date of birth</p>
 
-      <form @submit.prevent="handleCheckIn" class="kiosk-form">
+      <form @submit.prevent="handleLookup" class="kiosk-form">
         <div class="form-group">
           <label for="fullName">Full Name</label>
           <input
@@ -57,6 +57,52 @@
           Cancel
         </button>
       </form>
+    </div>
+
+    <!-- ── Profile photo capture ── -->
+    <div v-else-if="screen === 'photo'" class="kiosk-card photo-card">
+      <h2>Update Profile Photo</h2>
+      <p class="kiosk-instruction">
+        Look at the camera and take a photo for your patient profile. You can skip this step.
+      </p>
+
+      <div class="camera-frame">
+        <video
+          v-show="!capturedDataUrl"
+          ref="videoEl"
+          class="camera-preview mirror"
+          autoplay
+          playsinline
+          muted
+        ></video>
+        <img
+          v-if="capturedDataUrl"
+          :src="capturedDataUrl"
+          alt="Captured profile photo"
+          class="camera-preview"
+        />
+        <canvas ref="canvasEl" class="capture-canvas"></canvas>
+      </div>
+
+      <div v-if="!capturedDataUrl" class="photo-actions">
+        <button type="button" class="kiosk-btn primary" :disabled="!cameraReady || uploading" @click="takePhoto">
+          Take Photo
+        </button>
+        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
+          Skip
+        </button>
+      </div>
+      <div v-else class="photo-actions">
+        <button type="button" class="kiosk-btn primary" :disabled="uploading" @click="usePhoto">
+          {{ uploading ? 'Saving…' : 'Use Photo' }}
+        </button>
+        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="retakePhoto">
+          Retake
+        </button>
+        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
+          Skip
+        </button>
+      </div>
     </div>
 
     <!-- ── Success / confirmation screen ── -->
@@ -104,17 +150,25 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { ref, onMounted, onUnmounted, computed, nextTick } from 'vue'
 
 // ── State ─────────────────────────────────────────────────────────────────────
-type Screen = 'welcome' | 'form' | 'success'
+type Screen = 'welcome' | 'form' | 'photo' | 'success'
 
 const screen = ref<Screen>('welcome')
 const loading = ref(false)
+const uploading = ref(false)
 const appointmentInfo = ref<any>(null)
 const checkedInName = ref('')
+const cameraReady = ref(false)
+const capturedDataUrl = ref<string | null>(null)
+const capturedBlob = ref<Blob | null>(null)
 
 const form = ref({ fullName: '', dob: '', appointmentTime: '' })
+
+const videoEl = ref<HTMLVideoElement | null>(null)
+const canvasEl = ref<HTMLCanvasElement | null>(null)
+let mediaStream: MediaStream | null = null
 
 // ── Countdown (success screen only) ──────────────────────────────────────────
 const RESET_AFTER_SECS = 10
@@ -124,7 +178,8 @@ const countdownPct = computed(() => (countdownSecs.value / RESET_AFTER_SECS) * 1
 let countdownTimer: ReturnType<typeof setInterval> | null = null
 let inactivityTimer: ReturnType<typeof setTimeout> | null = null
 
-const INACTIVITY_MS = 10_000 // 10 s of no interaction resets from any screen
+const INACTIVITY_MS = 10_000
+const PHOTO_INACTIVITY_MS = 60_000
 
 function startCountdown() {
   countdownSecs.value = RESET_AFTER_SECS
@@ -140,12 +195,12 @@ function stopCountdown() {
   countdownTimer = null
 }
 
-// ── Inactivity reset (fires from form/welcome if user walks away) ─────────────
+// ── Inactivity reset (fires from form/welcome/photo if user walks away) ───────
 function resetInactivityTimer() {
   clearTimeout(inactivityTimer!)
-  if (screen.value !== 'welcome') {
-    inactivityTimer = setTimeout(() => reset(), INACTIVITY_MS)
-  }
+  if (screen.value === 'welcome') return
+  const delay = screen.value === 'photo' ? PHOTO_INACTIVITY_MS : INACTIVITY_MS
+  inactivityTimer = setTimeout(() => reset(), delay)
 }
 
 function clearInactivityTimer() {
@@ -153,25 +208,116 @@ function clearInactivityTimer() {
   inactivityTimer = null
 }
 
+function stopCamera() {
+  if (mediaStream) {
+    for (const track of mediaStream.getTracks()) {
+      track.stop()
+    }
+    mediaStream = null
+  }
+  if (videoEl.value) {
+    videoEl.value.srcObject = null
+  }
+  cameraReady.value = false
+}
+
+function clearCapture() {
+  capturedDataUrl.value = null
+  capturedBlob.value = null
+}
+
 // ── Reset to welcome ──────────────────────────────────────────────────────────
 function reset() {
   stopCountdown()
   clearInactivityTimer()
+  stopCamera()
+  clearCapture()
   screen.value = 'welcome'
   form.value = { fullName: '', dob: '', appointmentTime: '' }
   appointmentInfo.value = null
   checkedInName.value = ''
   loading.value = false
+  uploading.value = false
 }
 
-// ── API: look up appointment then check in ────────────────────────────────────
-async function handleCheckIn() {
+function goToSuccess(name: string, appointment: any | null) {
+  stopCamera()
+  clearCapture()
+  checkedInName.value = name
+  appointmentInfo.value = appointment
+  screen.value = 'success'
+  clearInactivityTimer()
+  startCountdown()
+}
+
+async function completeCheckIn(appointment: any) {
+  const patientName = form.value.fullName.trim()
+  try {
+    const checkinRes = await fetch(`/api/appointments/${appointment.id}/checkin-guest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        patient_name: patientName,
+        date_of_birth: form.value.dob,
+        appointment_time: form.value.appointmentTime,
+      }),
+    })
+    goToSuccess(patientName, checkinRes.ok ? appointment : null)
+  } catch (e) {
+    console.error('Kiosk check-in error:', e)
+    goToSuccess(patientName, null)
+  }
+}
+
+async function startFrontCamera(): Promise<boolean> {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    return false
+  }
+
+  const attempts: MediaStreamConstraints[] = [
+    { video: { facingMode: { exact: 'user' } }, audio: false },
+    { video: { facingMode: 'user' }, audio: false },
+    { video: true, audio: false },
+  ]
+
+  for (const constraints of attempts) {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(constraints)
+      mediaStream = stream
+      await nextTick()
+      if (videoEl.value) {
+        videoEl.value.srcObject = stream
+        await videoEl.value.play().catch(() => undefined)
+      }
+      cameraReady.value = true
+      return true
+    } catch {
+      // try next constraint
+    }
+  }
+  return false
+}
+
+async function openPhotoStep(appointment: any) {
+  appointmentInfo.value = appointment
+  clearCapture()
+  screen.value = 'photo'
+  resetInactivityTimer()
+  await nextTick()
+  const ok = await startFrontCamera()
+  if (!ok) {
+    // Auto-skip when camera is unavailable
+    await completeCheckIn(appointment)
+  }
+}
+
+// ── API: look up appointment, then photo step or success ──────────────────────
+async function handleLookup() {
   loading.value = true
 
   const patientName = form.value.fullName.trim()
 
   try {
-    // Step 1: find the patient's next upcoming appointment by name + DOB
     const lookupRes = await fetch('/api/appointments/kiosk/lookup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -183,45 +329,99 @@ async function handleCheckIn() {
     })
 
     if (!lookupRes.ok) {
-      // Patient not found — alert already sent server-side; show success anyway
-      checkedInName.value = patientName
-      appointmentInfo.value = null
-      screen.value = 'success'
-      clearInactivityTimer()
-      startCountdown()
+      goToSuccess(patientName, null)
       return
     }
 
     const { appointment } = await lookupRes.json()
-
-    // Step 2: check in via the no-auth guest endpoint
-    const checkinRes = await fetch(`/api/appointments/${appointment.id}/checkin-guest`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        patient_name: patientName,
-        date_of_birth: form.value.dob,
-        appointment_time: form.value.appointmentTime,
-      }),
-    })
-
-    checkedInName.value = patientName
-    // Show what we found even if the final checkin call failed
-    appointmentInfo.value = checkinRes.ok ? appointment : null
-    screen.value = 'success'
-    clearInactivityTimer()
-    startCountdown()
-
+    await openPhotoStep(appointment)
   } catch (e) {
     console.error('Kiosk check-in error:', e)
-    // Network/unexpected error — still send to success to avoid confusing patients
-    checkedInName.value = patientName
-    appointmentInfo.value = null
-    screen.value = 'success'
-    clearInactivityTimer()
-    startCountdown()
+    goToSuccess(patientName, null)
   } finally {
     loading.value = false
+  }
+}
+
+function takePhoto() {
+  const video = videoEl.value
+  const canvas = canvasEl.value
+  if (!video || !canvas || !cameraReady.value) return
+
+  const width = video.videoWidth || 640
+  const height = video.videoHeight || 480
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+
+  // Draw un-mirrored frame (preview is CSS-mirrored only)
+  ctx.drawImage(video, 0, 0, width, height)
+
+  capturedDataUrl.value = canvas.toDataURL('image/jpeg', 0.92)
+  canvas.toBlob(
+    (blob) => {
+      capturedBlob.value = blob
+    },
+    'image/jpeg',
+    0.92,
+  )
+  resetInactivityTimer()
+}
+
+async function retakePhoto() {
+  clearCapture()
+  resetInactivityTimer()
+  if (!mediaStream) {
+    const ok = await startFrontCamera()
+    if (!ok) {
+      await skipPhoto()
+    }
+  }
+}
+
+async function uploadCapturedPhoto(appointment: any): Promise<boolean> {
+  if (!capturedBlob.value || !appointment?.patient_id) return false
+
+  const body = new FormData()
+  body.append('file', capturedBlob.value, 'profile-photo.jpg')
+  body.append('patient_name', form.value.fullName.trim())
+  body.append('date_of_birth', form.value.dob)
+
+  try {
+    const res = await fetch(`/api/patients/${appointment.patient_id}/profile-photo/kiosk`, {
+      method: 'POST',
+      body,
+    })
+    return res.ok
+  } catch (e) {
+    console.error('Profile photo upload error:', e)
+    return false
+  }
+}
+
+async function usePhoto() {
+  if (!appointmentInfo.value) return
+  uploading.value = true
+  try {
+    // Upload failure must not block check-in
+    await uploadCapturedPhoto(appointmentInfo.value)
+    await completeCheckIn(appointmentInfo.value)
+  } finally {
+    uploading.value = false
+  }
+}
+
+async function skipPhoto() {
+  if (!appointmentInfo.value) {
+    goToSuccess(form.value.fullName.trim(), null)
+    return
+  }
+  uploading.value = true
+  try {
+    await completeCheckIn(appointmentInfo.value)
+  } finally {
+    uploading.value = false
   }
 }
 
@@ -245,6 +445,7 @@ onMounted(() => {
 onUnmounted(() => {
   stopCountdown()
   clearInactivityTimer()
+  stopCamera()
   globalThis.removeEventListener('mousemove', resetInactivityTimer)
   globalThis.removeEventListener('touchstart', resetInactivityTimer)
 })
@@ -271,6 +472,10 @@ onUnmounted(() => {
   width: 100%;
   text-align: center;
   animation: fadeSlideIn 0.3s ease-out;
+}
+
+.photo-card {
+  max-width: 640px;
 }
 
 @keyframes fadeSlideIn {
@@ -310,6 +515,38 @@ h2 {
   color: #546e7a;
   margin: 0 0 28px;
   line-height: 1.5;
+}
+
+/* ── Camera ────────────────────────────────────────────────────────────────── */
+.camera-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: #0f172a;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.camera-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.camera-preview.mirror {
+  transform: scaleX(-1);
+}
+
+.capture-canvas {
+  display: none;
+}
+
+.photo-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 /* ── Buttons ───────────────────────────────────────────────────────────────── */
@@ -390,17 +627,6 @@ input {
 input:focus {
   outline: none;
   border-color: #3949ab;
-}
-
-.kiosk-error {
-  background: #fff3f3;
-  border: 1px solid #f5c6c6;
-  color: #c62828;
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 18px;
-  font-size: 0.95rem;
-  line-height: 1.4;
 }
 
 /* ── Success card ──────────────────────────────────────────────────────────── */

--- a/src/views/PatientsView.vue
+++ b/src/views/PatientsView.vue
@@ -30,11 +30,23 @@
 
       <section class="patient-detail" v-if="selectedPatient">
         <div class="detail-header">
-          <div>
-            <h2>{{ selectedPatient.first_name }} {{ selectedPatient.last_name }}</h2>
-            <div class="banner-meta">
-              <span>DOB: {{ formatDate(selectedPatient.date_of_birth) }}</span>
-              <span v-if="selectedPatient.phone">Phone: {{ selectedPatient.phone }}</span>
+          <div class="detail-header-main">
+            <div class="patient-avatar">
+              <img
+                v-if="selectedPatientPhotoUrl"
+                :src="selectedPatientPhotoUrl"
+                :alt="`${selectedPatient.first_name} ${selectedPatient.last_name}`"
+              />
+              <span v-else class="patient-avatar-fallback">
+                {{ selectedPatientInitials }}
+              </span>
+            </div>
+            <div>
+              <h2>{{ selectedPatient.first_name }} {{ selectedPatient.last_name }}</h2>
+              <div class="banner-meta">
+                <span>DOB: {{ formatDate(selectedPatient.date_of_birth) }}</span>
+                <span v-if="selectedPatient.phone">Phone: {{ selectedPatient.phone }}</span>
+              </div>
             </div>
           </div>
           <span class="badge" :class="{ linked: !!selectedPatient.user_id }">
@@ -852,6 +864,43 @@ const selectedPatient = computed(() =>
   patients.value.find(p => p.id === selectedPatientId.value) || null
 )
 
+const selectedPatientPhotoUrl = ref<string | null>(null)
+
+const selectedPatientInitials = computed(() => {
+  const p = selectedPatient.value
+  if (!p) return '?'
+  const first = (p.first_name || '').charAt(0)
+  const last = (p.last_name || '').charAt(0)
+  return `${first}${last}`.toUpperCase() || '?'
+})
+
+function clearSelectedPatientPhoto() {
+  if (selectedPatientPhotoUrl.value) {
+    URL.revokeObjectURL(selectedPatientPhotoUrl.value)
+    selectedPatientPhotoUrl.value = null
+  }
+}
+
+async function loadSelectedPatientPhoto() {
+  clearSelectedPatientPhoto()
+  const patient = selectedPatient.value
+  if (!patient?.has_profile_photo) return
+
+  const token = localStorage.getItem('sessionToken')
+  if (!token) return
+
+  try {
+    const response = await fetch(`/api/patients/${patient.id}/profile-photo`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) return
+    const blob = await response.blob()
+    selectedPatientPhotoUrl.value = URL.createObjectURL(blob)
+  } catch (error) {
+    console.error('Failed to load patient profile photo:', error)
+  }
+}
+
 function selectPatient(patient: Patient) {
   selectedPatientId.value = patient.id
 }
@@ -1238,11 +1287,13 @@ onMounted(() => {
 onBeforeUnmount(() => {
   window.removeEventListener('beforeunload', handleBeforeUnload)
   clearPendingSaves()
+  clearSelectedPatientPhoto()
 })
 
 watch(selectedPatientId, () => {
   clearPendingSaves()
   activeChartTab.value = 'summary'
+  loadSelectedPatientPhoto()
   loadProperties()
   loadDocuments()
   loadChartSummary()
@@ -1915,6 +1966,37 @@ async function toggleDocumentVisibility(doc: PatientDocument) {
   justify-content: space-between;
   gap: 1rem;
   margin-bottom: 1.5rem;
+}
+
+.detail-header-main {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.patient-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.patient-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.patient-avatar-fallback {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #4b5563;
 }
 
 .detail-header h2 {

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -8,6 +8,17 @@
           Review your account details and update your password any time.
         </p>
 
+        <div v-if="currentUser?.role === 'patient'" class="profile-photo-row">
+          <div class="profile-photo">
+            <img v-if="profilePhotoUrl" :src="profilePhotoUrl" alt="Profile photo" />
+            <span v-else class="profile-photo-fallback">{{ initials }}</span>
+          </div>
+          <div class="profile-photo-meta">
+            <span class="label">Profile photo</span>
+            <span class="value">{{ profilePhotoUrl ? 'Updated at check-in' : 'No photo on file' }}</span>
+          </div>
+        </div>
+
         <div class="account-grid">
           <div class="account-item">
             <span class="label">Username</span>
@@ -89,7 +100,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { authApi } from '@/api'
 
@@ -103,6 +114,7 @@ type StoredUser = {
 const route = useRoute()
 const router = useRouter()
 const currentUser = ref<StoredUser | null>(null)
+const profilePhotoUrl = ref<string | null>(null)
 
 function loadCurrentUser() {
   const storedUser = localStorage.getItem('currentUser')
@@ -118,8 +130,51 @@ function loadCurrentUser() {
   }
 }
 
-onMounted(() => {
+function clearProfilePhotoUrl() {
+  if (profilePhotoUrl.value) {
+    URL.revokeObjectURL(profilePhotoUrl.value)
+    profilePhotoUrl.value = null
+  }
+}
+
+async function loadPatientProfilePhoto() {
+  clearProfilePhotoUrl()
+  if (currentUser.value?.role !== 'patient') return
+
+  const token = localStorage.getItem('sessionToken')
+  if (!token) return
+
+  try {
+    const meRes = await fetch('/api/patients/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!meRes.ok) return
+    const { patient } = await meRes.json()
+    if (!patient?.has_profile_photo || !patient?.id) return
+
+    const photoRes = await fetch(`/api/patients/${patient.id}/profile-photo`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!photoRes.ok) return
+    const blob = await photoRes.blob()
+    profilePhotoUrl.value = URL.createObjectURL(blob)
+  } catch (error) {
+    console.error('Failed to load profile photo:', error)
+  }
+}
+
+onMounted(async () => {
   loadCurrentUser()
+  await loadPatientProfilePhoto()
+})
+
+onUnmounted(() => {
+  clearProfilePhotoUrl()
+})
+
+const initials = computed(() => {
+  const name = currentUser.value?.username || ''
+  return name.slice(0, 2).toUpperCase() || '?'
 })
 
 const formattedRole = computed(() => {
@@ -240,6 +295,42 @@ async function handlePasswordChange() {
   margin: 0.75rem 0 1.5rem;
   color: #475569;
   line-height: 1.5;
+}
+
+.profile-photo-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.profile-photo {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #e2e8f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.profile-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-photo-fallback {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #475569;
+}
+
+.profile-photo-meta {
+  display: grid;
+  gap: 0.25rem;
 }
 
 .account-grid {

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -115,6 +115,7 @@ const route = useRoute()
 const router = useRouter()
 const currentUser = ref<StoredUser | null>(null)
 const profilePhotoUrl = ref<string | null>(null)
+const patientName = ref<{ first_name?: string; last_name?: string } | null>(null)
 
 function loadCurrentUser() {
   const storedUser = localStorage.getItem('currentUser')
@@ -150,6 +151,9 @@ async function loadPatientProfilePhoto() {
     })
     if (!meRes.ok) return
     const { patient } = await meRes.json()
+    patientName.value = patient
+      ? { first_name: patient.first_name, last_name: patient.last_name }
+      : null
     if (!patient?.has_profile_photo || !patient?.id) return
 
     const photoRes = await fetch(`/api/patients/${patient.id}/profile-photo`, {
@@ -173,6 +177,10 @@ onUnmounted(() => {
 })
 
 const initials = computed(() => {
+  const first = (patientName.value?.first_name || '').charAt(0)
+  const last = (patientName.value?.last_name || '').charAt(0)
+  const fromName = `${first}${last}`.toUpperCase()
+  if (fromName) return fromName
   const name = currentUser.value?.username || ''
   return name.slice(0, 2).toUpperCase() || '?'
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an optional front-facing camera step to the tablet kiosk check-in flow so patients can update their profile photo when checking in.

## Changes
- **Kiosk UI** (`KioskView`): after a successful appointment lookup, show a skippable photo step using `facingMode: 'user'`; auto-skip if the camera fails; then proceed with guest check-in.
- **Storage**: profile JPEGs are stored via the existing documents storage backend as `medical_documents` rows with `document_type = 'profile_photo'`, linked from `patients.profile_photo_document_id`.
- **Document lists**: profile photos are excluded from `GET /api/documents/<patient_id>` so they do not appear in the patient documents UI.
- **APIs**:
  - `POST /api/patients/<id>/profile-photo/kiosk` (no auth; gated by name + DOB)
  - `GET /api/patients/<id>/profile-photo` (patient own / any doctor)
  - `has_profile_photo` on patient list and `/me` responses
- **Display**: photo shown on the patient’s Profile page and the provider Patients chart header (initials fallback when missing).

## Testing
- API tests in `api/tests/test_profile_photo.py` (upload, identity mismatch, list exclusion, authz).
- Manual: open `/kiosk`, check in a seeded patient, capture or skip photo, confirm display on Profile / Patients.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de3ebe6a-3d12-4faa-b1fa-aaa192b7f974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de3ebe6a-3d12-4faa-b1fa-aaa192b7f974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

