### PR TITLE
Fix Release 2.0 review blockers from PR #37

### DIFF
--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -49,7 +49,7 @@ def authenticate(f):
         if not session:
             return jsonify({'error': 'Invalid or expired session'}), 401
         
-        # Get user details
+        # Get user details — require is_active (fail closed if column missing).
         query = """
             SELECT id, username, role, email
             FROM users
@@ -58,16 +58,9 @@ def authenticate(f):
         try:
             user = execute_query(query, (session['user_id'],), fetch_one=True)
         except Exception as exc:
-            if isinstance(exc, pg_errors.UndefinedTable):
+            if isinstance(exc, (pg_errors.UndefinedTable, pg_errors.UndefinedColumn)):
                 return _schema_not_initialized_response()
-            if not isinstance(exc, pg_errors.UndefinedColumn):
-                raise
-            fallback_query = """
-                SELECT id, username, role, email
-                FROM users
-                WHERE id = %s
-            """
-            user = execute_query(fallback_query, (session['user_id'],), fetch_one=True)
+            raise
         
         if not user:
             return jsonify({'error': 'User not found or inactive'}), 401
@@ -117,11 +110,9 @@ def check_account_lock(f):
         try:
             result = execute_query(query, (username,), fetch_one=True)
         except Exception as exc:
-            if isinstance(exc, pg_errors.UndefinedTable):
+            if isinstance(exc, (pg_errors.UndefinedTable, pg_errors.UndefinedColumn)):
                 return _schema_not_initialized_response()
-            if not isinstance(exc, pg_errors.UndefinedColumn):
-                raise
-            result = None
+            raise
         
         if result and result['account_locked_until']:
             lockout_time = result['account_locked_until']

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -41,7 +41,21 @@ def _is_undefined_column_error(exc):
     return isinstance(exc, pg_errors.UndefinedColumn)
 
 
+def _schema_incomplete_login_response():
+    return jsonify({
+        'error': (
+            'Authentication database schema is incomplete. '
+            'Apply database migrations and try again.'
+        ),
+    }), 503
+
+
 def _fetch_login_user(username):
+    """
+    Fetch login user including lockout columns.
+
+    Fail closed if auth columns are missing — never weaken lockout / is_active.
+    """
     query = """
         SELECT id, username, email, role, password_hash, salt,
                failed_login_attempts, account_locked_until, is_active,
@@ -51,32 +65,15 @@ def _fetch_login_user(username):
     """
     try:
         user = execute_query(query, (username,), fetch_one=True)
-        if user:
-            user = dict(user)
-            user['_supports_lockout_columns'] = True
-        return user
+        return dict(user) if user else None
     except Exception as exc:
         if not _is_undefined_column_error(exc):
             raise
-        current_app.logger.warning(
-            "Users table missing one or more auth columns during login; using compatibility query"
+        current_app.logger.error(
+            "Users table missing auth/lockout columns during login; refusing login"
         )
-        fallback_query = """
-            SELECT id, username, email, role, password_hash, salt
-            FROM users
-            WHERE username = %s
-        """
-        user = execute_query(fallback_query, (username,), fetch_one=True)
-        if not user:
-            return None
-        user = dict(user)
-        user['failed_login_attempts'] = 0
-        user['account_locked_until'] = None
-        user['is_active'] = True
-        user['password_last_changed'] = None
-        user['must_change_password'] = False
-        user['_supports_lockout_columns'] = False
-        return user
+        # Signal to login() via sentinel that schema is incomplete.
+        return {'_schema_incomplete': True}
 
 
 def _verify_login_password(submitted_password, user):
@@ -214,6 +211,9 @@ def login():
         
         # Get user
         user = _fetch_login_user(username)
+
+        if user and user.get('_schema_incomplete'):
+            return _schema_incomplete_login_response()
         
         if not user:
             log_login(None, username, False, request)
@@ -228,57 +228,52 @@ def login():
         valid_password = _verify_login_password(password, user)
         
         if not valid_password:
-            if user.get('_supports_lockout_columns'):
-                # Increment failed login attempts
-                max_attempts = int(os.getenv('MAX_LOGIN_ATTEMPTS', 5))
-                lockout_minutes = int(os.getenv('ACCOUNT_LOCKOUT_MINUTES', 30))
-                new_attempts = (user['failed_login_attempts'] or 0) + 1
+            # Increment failed login attempts
+            max_attempts = int(os.getenv('MAX_LOGIN_ATTEMPTS', 5))
+            lockout_minutes = int(os.getenv('ACCOUNT_LOCKOUT_MINUTES', 30))
+            new_attempts = (user['failed_login_attempts'] or 0) + 1
 
-                if new_attempts >= max_attempts:
-                    lockout_until = datetime.now() + timedelta(minutes=lockout_minutes)
-
-                    update_query = """
-                        UPDATE users
-                        SET failed_login_attempts = %s,
-                            account_locked_until = %s,
-                            last_failed_login = NOW()
-                        WHERE id = %s
-                    """
-                    execute_query(update_query, (new_attempts, lockout_until, user['id']))
-
-                    log_account_lockout(user['id'], 'Too many failed login attempts', request)
-
-                    return jsonify({
-                        'error': 'Account locked due to too many failed login attempts',
-                        'minutesLocked': lockout_minutes
-                    }), 423
+            if new_attempts >= max_attempts:
+                lockout_until = datetime.now() + timedelta(minutes=lockout_minutes)
 
                 update_query = """
                     UPDATE users
                     SET failed_login_attempts = %s,
+                        account_locked_until = %s,
                         last_failed_login = NOW()
                     WHERE id = %s
                 """
-                execute_query(update_query, (new_attempts, user['id']))
+                execute_query(update_query, (new_attempts, lockout_until, user['id']))
 
-                log_login(user['id'], username, False, request)
+                log_account_lockout(user['id'], 'Too many failed login attempts', request)
 
                 return jsonify({
-                    'error': 'Invalid credentials',
-                    'attemptsRemaining': max_attempts - new_attempts
-                }), 401
+                    'error': 'Account locked due to too many failed login attempts',
+                    'minutesLocked': lockout_minutes
+                }), 423
 
-            log_login(user['id'], username, False, request)
-            return jsonify({'error': 'Invalid credentials'}), 401
-        
-        # Reset failed login attempts
-        if user.get('_supports_lockout_columns'):
-            reset_query = """
+            update_query = """
                 UPDATE users
-                SET failed_login_attempts = 0, account_locked_until = NULL, last_login = NOW()
+                SET failed_login_attempts = %s,
+                    last_failed_login = NOW()
                 WHERE id = %s
             """
-            execute_query(reset_query, (user['id'],))
+            execute_query(update_query, (new_attempts, user['id']))
+
+            log_login(user['id'], username, False, request)
+
+            return jsonify({
+                'error': 'Invalid credentials',
+                'attemptsRemaining': max_attempts - new_attempts
+            }), 401
+        
+        # Reset failed login attempts
+        reset_query = """
+            UPDATE users
+            SET failed_login_attempts = 0, account_locked_until = NULL, last_login = NOW()
+            WHERE id = %s
+        """
+        execute_query(reset_query, (user['id'],))
         
         # Check if password has expired
         password_expiry_days = int(os.getenv('PASSWORD_EXPIRY_DAYS', 90))

--- a/api/routes/documents.py
+++ b/api/routes/documents.py
@@ -14,6 +14,7 @@ from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
 from api.db.connection import execute_query
 from api.middleware.auth import authenticate
+from api.utils.audit_log import log_data_access, log_audit_event, get_client_ip
 
 documents_bp = Blueprint('documents', __name__, url_prefix='/api/documents')
 INSUFFICIENT_PERMISSIONS_ERROR = 'Insufficient permissions'
@@ -319,6 +320,27 @@ def upload_document(patient_id):
         return jsonify({'error': FAILED_UPLOAD_DOCUMENTS_ERROR}), 500
 
 
+def _get_mutable_document(doc_id):
+    """
+    Fetch a document that may be mutated via the generic document APIs.
+    Profile photos are managed only through the dedicated profile-photo endpoints.
+    """
+    doc = execute_query(
+        f"""
+        SELECT {DOCUMENT_COLUMNS}
+        FROM medical_documents
+        WHERE id = %s
+        """,
+        (doc_id,),
+        fetch_one=True,
+    )
+    if not doc:
+        return None, (jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404)
+    if doc.get('document_type') == 'profile_photo':
+        return None, (jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404)
+    return doc, None
+
+
 @documents_bp.route('/<doc_id>/rename', methods=['PUT'])
 @authenticate
 def rename_document(doc_id):
@@ -337,12 +359,17 @@ def rename_document(doc_id):
         
         if not new_title:
             return jsonify({'error': 'Title is required'}), 400
+
+        existing, error_response = _get_mutable_document(doc_id)
+        if error_response:
+            return error_response
         
         # Update document title
         update_query = f"""
             UPDATE medical_documents
             SET title = %s, updated_at = CURRENT_TIMESTAMP
             WHERE id = %s
+              AND document_type IS DISTINCT FROM 'profile_photo'
             RETURNING {DOCUMENT_COLUMNS}
         """
         
@@ -350,6 +377,8 @@ def rename_document(doc_id):
         
         if not doc:
             return jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404
+
+        log_data_access(user['id'], 'medical_documents', doc_id, 'UPDATE', request)
         
         return jsonify({
             'message': 'Document renamed successfully',
@@ -380,16 +409,37 @@ def update_document_visibility(doc_id):
 
         patient_visible = _parse_patient_visible(data.get('patient_visible'), default=False)
 
+        existing, error_response = _get_mutable_document(doc_id)
+        if error_response:
+            return error_response
+
+        previous_visible = bool(existing.get('patient_visible'))
+
         update_query = f"""
             UPDATE medical_documents
             SET patient_visible = %s, updated_at = CURRENT_TIMESTAMP
             WHERE id = %s
+              AND document_type IS DISTINCT FROM 'profile_photo'
             RETURNING {DOCUMENT_COLUMNS}
         """
         doc = execute_query(update_query, (patient_visible, doc_id), fetch_one=True)
 
         if not doc:
             return jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404
+
+        log_audit_event(
+            user_id=user['id'],
+            action='DATA_UPDATE',
+            table_name='medical_documents',
+            record_id=doc_id,
+            ip_address=get_client_ip(request),
+            user_agent=request.headers.get('User-Agent'),
+            details={
+                'field': 'patient_visible',
+                'old_patient_visible': previous_visible,
+                'new_patient_visible': bool(doc.get('patient_visible')),
+            },
+        )
 
         return jsonify({
             'message': 'Document visibility updated',
@@ -414,21 +464,24 @@ def delete_document(doc_id):
         if user.get('role') != 'doctor':
             return jsonify({'error': INSUFFICIENT_PERMISSIONS_ERROR}), 403
         
-        # Get document to find file path
-        get_query = "SELECT file_path FROM medical_documents WHERE id = %s"
-        doc = execute_query(get_query, (doc_id,), fetch_one=True)
-        
-        if not doc:
-            return jsonify({'error': DOCUMENT_NOT_FOUND_ERROR}), 404
+        existing, error_response = _get_mutable_document(doc_id)
+        if error_response:
+            return error_response
         
         # Delete from database
-        delete_query = "DELETE FROM medical_documents WHERE id = %s RETURNING id"
+        delete_query = """
+            DELETE FROM medical_documents
+            WHERE id = %s
+              AND document_type IS DISTINCT FROM 'profile_photo'
+            RETURNING id, file_path
+        """
         result = execute_query(delete_query, (doc_id,), fetch_one=True)
         
         if not result:
             return jsonify({'error': FAILED_DELETE_DOCUMENT_ERROR}), 500
 
-        _delete_file_from_storage(doc.get('file_path') or '')
+        _delete_file_from_storage(result.get('file_path') or existing.get('file_path') or '')
+        log_data_access(user['id'], 'medical_documents', doc_id, 'DELETE', request)
 
         return jsonify({'message': 'Document deleted successfully'}), 200
 

--- a/api/routes/messages.py
+++ b/api/routes/messages.py
@@ -212,6 +212,41 @@ def _can_message_user(actor, target_user_id):
     return False
 
 
+def _patient_user_ids(user_ids):
+    """Return the subset of user_ids that belong to active patient accounts."""
+    ids = [str(uid) for uid in user_ids if uid]
+    if not ids:
+        return set()
+    placeholders = ','.join(['%s'] * len(ids))
+    rows = execute_query(
+        f"""
+        SELECT id
+        FROM users
+        WHERE role = 'patient'
+          AND id IN ({placeholders})
+        """,
+        tuple(ids),
+        fetch_all=True,
+    ) or []
+    return {str(row['id']) for row in rows}
+
+
+def _channel_patient_ids(conversation_id):
+    """Return patient user IDs already participating in a channel."""
+    rows = execute_query(
+        """
+        SELECT u.id
+        FROM conversation_participants cp
+        JOIN users u ON u.id = cp.user_id
+        WHERE cp.conversation_id = %s
+          AND u.role = 'patient'
+        """,
+        (conversation_id,),
+        fetch_all=True,
+    ) or []
+    return {str(row['id']) for row in rows}
+
+
 def _list_participants(conversation_id):
     rows = execute_query(
         """
@@ -528,6 +563,12 @@ def create_conversation():
                     return jsonify({'error': f'Cannot add participant {raw_id}'}), 403
                 resolved_ids.add(str(raw_id))
 
+            # HIPAA: at most one patient per channel so patients cannot see each other.
+            if len(_patient_user_ids(resolved_ids)) > 1:
+                return jsonify({
+                    'error': 'Channels may include at most one patient',
+                }), 400
+
             with DatabaseTransaction() as cursor:
                 cursor.execute(
                     """
@@ -813,6 +854,14 @@ def add_participants(conversation_id):
         participant_ids = data.get('participant_user_ids') or []
         if not isinstance(participant_ids, list) or not participant_ids:
             return jsonify({'error': 'participant_user_ids is required'}), 400
+
+        # HIPAA: reject adding a second patient to a channel that already has one.
+        existing_patients = _channel_patient_ids(conversation_id)
+        new_patients = _patient_user_ids(participant_ids)
+        if len(existing_patients | new_patients) > 1:
+            return jsonify({
+                'error': 'Channels may include at most one patient',
+            }), 400
 
         added = []
         with DatabaseTransaction() as cursor:

--- a/api/tests/test_messages.py
+++ b/api/tests/test_messages.py
@@ -134,6 +134,51 @@ def test_doctor_can_create_channel_and_non_participant_cannot_read(client):
 
 
 @requires_db
+def test_channel_rejects_second_patient_participant(client):
+    """HIPAA: channels may include at most one patient."""
+    doctor_headers = login_as(client, 'doctor1')
+    patient1_id = _user_id('patient1')
+    patient2_id = _user_id('patient2')
+
+    multi_create = client.post(
+        '/api/conversations',
+        headers=doctor_headers,
+        json={
+            'type': 'channel',
+            'title': 'Multi Patient Blocked',
+            'participant_user_ids': [patient1_id, patient2_id],
+        },
+    )
+    assert multi_create.status_code == 400, multi_create.get_json()
+    assert 'at most one patient' in multi_create.get_json()['error'].lower()
+
+    create_response = client.post(
+        '/api/conversations',
+        headers=doctor_headers,
+        json={
+            'type': 'channel',
+            'title': 'Single Patient Channel',
+            'participant_user_ids': [patient1_id],
+        },
+    )
+    assert create_response.status_code == 201, create_response.get_json()
+    conversation_id = create_response.get_json()['conversation']['id']
+
+    add_response = client.post(
+        f'/api/conversations/{conversation_id}/participants',
+        headers=doctor_headers,
+        json={'participant_user_ids': [patient2_id]},
+    )
+    assert add_response.status_code == 400, add_response.get_json()
+    assert 'at most one patient' in add_response.get_json()['error'].lower()
+
+    execute_query(
+        "DELETE FROM conversations WHERE id = %s",
+        (conversation_id,),
+    )
+
+
+@requires_db
 def test_unread_count_updates_after_read(client):
     doctor_headers = login_as(client, 'doctor1')
     patient_headers = login_as(client, 'patient1', 'Patient123!')

--- a/api/tests/test_profile_photo.py
+++ b/api/tests/test_profile_photo.py
@@ -129,6 +129,52 @@ def test_profile_photo_excluded_from_document_list(client):
 
 
 @requires_db
+def test_profile_photo_not_mutable_via_generic_document_apis(client):
+    patient = _get_patient('patient1')
+    upload = _upload_kiosk_photo(client, patient)
+    assert upload.status_code == 201, upload.get_json()
+
+    photo = execute_query(
+        """
+        SELECT id
+        FROM medical_documents
+        WHERE patient_id = %s AND document_type = 'profile_photo'
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (patient['id'],),
+        fetch_one=True,
+    )
+    assert photo is not None
+    doc_id = str(photo['id'])
+    doctor_headers = login_as(client, 'doctor1')
+
+    rename = client.put(
+        f'/api/documents/{doc_id}/rename',
+        headers=doctor_headers,
+        json={'title': 'Should Not Rename'},
+    )
+    assert rename.status_code == 404
+
+    visibility = client.put(
+        f'/api/documents/{doc_id}/visibility',
+        headers=doctor_headers,
+        json={'patient_visible': False},
+    )
+    assert visibility.status_code == 404
+
+    delete = client.delete(f'/api/documents/{doc_id}', headers=doctor_headers)
+    assert delete.status_code == 404
+
+    still_there = execute_query(
+        "SELECT id FROM medical_documents WHERE id = %s",
+        (doc_id,),
+        fetch_one=True,
+    )
+    assert still_there is not None
+
+
+@requires_db
 def test_kiosk_profile_photo_rejects_non_jpeg(client):
     patient = _get_patient('patient1')
     data = {

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -21,6 +21,22 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Upgrade legacy users tables that predate lockout / password-policy columns.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_login_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS account_locked_until TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_failed_login TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS password_last_changed TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE users ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    id TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS patients (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
@@ -107,6 +123,30 @@ CREATE TABLE IF NOT EXISTS medical_documents (
 
 ALTER TABLE medical_documents
     ADD COLUMN IF NOT EXISTS patient_visible BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- One-time: documents that existed before patient_visible were always patient-accessible.
+-- New uploads still default to FALSE in the application layer.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM schema_migrations
+        WHERE id = 'medical_documents_patient_visible_legacy_backfill'
+    ) THEN
+        UPDATE medical_documents
+        SET patient_visible = TRUE
+        WHERE patient_visible = FALSE
+          AND document_type IS DISTINCT FROM 'profile_photo';
+
+        -- Keep the seeded provider-only sample hidden after the legacy restore.
+        UPDATE medical_documents
+        SET patient_visible = FALSE
+        WHERE title = 'Internal Chart Review Notes'
+          AND description = 'Provider-only clinical notes';
+
+        INSERT INTO schema_migrations (id)
+        VALUES ('medical_documents_patient_visible_legacy_backfill');
+    END IF;
+END $$;
 
 -- Profile photos are stored as medical_documents rows (document_type = 'profile_photo')
 -- and pointed to from patients; excluded from document list APIs.

--- a/src/views/MessagesView.vue
+++ b/src/views/MessagesView.vue
@@ -512,6 +512,12 @@ async function sendTopLevelMessage() {
     return
   }
 
+  // User may have switched conversations while the send was in flight.
+  if (selectedConversationId.value !== conversationId) {
+    await loadConversations({ quiet: true })
+    return
+  }
+
   draft.value = ''
   messages.value = [...messages.value, response.data.message]
   await loadConversations({ quiet: true })
@@ -622,6 +628,15 @@ async function sendThreadReply() {
     return
   }
 
+  // User may have switched conversation/thread while the send was in flight.
+  if (
+    selectedConversationId.value !== conversationId ||
+    activeThreadRoot.value?.id !== root.id
+  ) {
+    await loadConversations({ quiet: true })
+    return
+  }
+
   threadDraft.value = ''
   threadReplies.value = [...threadReplies.value, response.data.message]
   const parent = messages.value.find((m) => m.id === root.id)
@@ -657,6 +672,13 @@ async function loadContacts() {
   contacts.value = response.data.contacts
 }
 
+function countSelectedPatients(userIds: string[]): number {
+  const selected = new Set(userIds)
+  return contacts.value.filter(
+    (contact) => selected.has(contact.user_id) && contact.role === 'patient',
+  ).length
+}
+
 async function submitCompose() {
   composeError.value = ''
   composeSubmitting.value = true
@@ -665,6 +687,11 @@ async function submitCompose() {
   if (composeMode.value === 'channel') {
     if (!channelTitle.value.trim()) {
       composeError.value = 'Channel name is required'
+      composeSubmitting.value = false
+      return
+    }
+    if (countSelectedPatients(selectedContactIds.value) > 1) {
+      composeError.value = 'Channels may include at most one patient'
       composeSubmitting.value = false
       return
     }
@@ -713,6 +740,13 @@ function closeAddPeople() {
 async function submitAddPeople() {
   if (!selectedConversationId.value || addPeopleIds.value.length === 0) {
     addPeopleError.value = 'Select at least one person'
+    return
+  }
+  const existingPatientCount = (
+    selectedConversation.value?.participants || []
+  ).filter((participant) => participant.role === 'patient').length
+  if (existingPatientCount + countSelectedPatients(addPeopleIds.value) > 1) {
+    addPeopleError.value = 'Channels may include at most one patient'
     return
   }
   addPeopleSubmitting.value = true

--- a/src/views/PatientsView.vue
+++ b/src/views/PatientsView.vue
@@ -994,7 +994,10 @@ function clearPendingSaves() {
   saveStatuses.value = {}
 }
 
-function mergePropertyFromServer(property: PatientProperty) {
+function mergePropertyFromServer(
+  property: PatientProperty,
+  sentPayload?: { name: string; description: string },
+) {
   const idx = patientProperties.value.findIndex(p => p.property_id === property.property_id)
   if (idx === -1) {
     patientProperties.value = [...patientProperties.value, property]
@@ -1003,6 +1006,38 @@ function mergePropertyFromServer(property: PatientProperty) {
     next[idx] = property
     patientProperties.value = next
   }
+
+  const currentDraft = propertyDrafts.value[property.property_id]
+  const hasPendingTimer = debounceTimers.has(property.property_id)
+  const draftMovedAhead = Boolean(
+    sentPayload
+    && currentDraft
+    && (
+      currentDraft.name !== sentPayload.name
+      || currentDraft.description !== sentPayload.description
+    ),
+  )
+
+  // Keep newer local keystrokes; only refresh concurrency token from the server.
+  if (hasPendingTimer || draftMovedAhead) {
+    if (currentDraft) {
+      propertyDrafts.value = {
+        ...propertyDrafts.value,
+        [property.property_id]: {
+          ...currentDraft,
+          updated_at: property.updated_at,
+        },
+      }
+    }
+    if (draftMovedAhead && !hasPendingTimer) {
+      const prop = patientProperties.value.find(p => p.property_id === property.property_id)
+      if (prop) {
+        schedulePropertySave(prop)
+      }
+    }
+    return
+  }
+
   propertyDrafts.value = {
     ...propertyDrafts.value,
     [property.property_id]: {
@@ -1040,8 +1075,13 @@ function schedulePropertySave(prop: PatientProperty) {
   debounceTimers.set(prop.property_id, timer)
 }
 
-async function persistPropertyDraft(prop: PatientProperty, keepalive = false) {
-  if (!selectedPatientId.value) return
+async function persistPropertyDraft(
+  prop: PatientProperty,
+  keepalive = false,
+  patientIdOverride?: string | null,
+) {
+  const patientId = patientIdOverride ?? selectedPatientId.value
+  if (!patientId) return
 
   const draft = getPropertyDraft(prop)
   if (!draft.name.trim()) {
@@ -1059,7 +1099,7 @@ async function persistPropertyDraft(prop: PatientProperty, keepalive = false) {
 
   if (keepalive) {
     const token = localStorage.getItem('sessionToken')
-    fetch(`/api/patient-properties/${selectedPatientId.value}/${prop.property_id}`, {
+    fetch(`/api/patient-properties/${patientId}/${prop.property_id}`, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
@@ -1072,10 +1112,15 @@ async function persistPropertyDraft(prop: PatientProperty, keepalive = false) {
   }
 
   const response = await patientPropertiesApi.update(
-    selectedPatientId.value,
+    patientId,
     prop.property_id,
     payload,
   )
+
+  // Patient may have changed while the save was in flight.
+  if (selectedPatientId.value !== patientId) {
+    return
+  }
 
   if (handleApiAuthFailure(response.error)) {
     return
@@ -1094,12 +1139,16 @@ async function persistPropertyDraft(prop: PatientProperty, keepalive = false) {
     return
   }
 
-  mergePropertyFromServer(response.data.property)
+  mergePropertyFromServer(response.data.property, {
+    name: payload.name,
+    description: payload.description,
+  })
   setSaveStatus(prop.property_id, 'saved')
   propertiesError.value = ''
 }
 
-function flushPendingSaves() {
+function flushPendingSaves(patientIdOverride?: string | null) {
+  const patientId = patientIdOverride ?? selectedPatientId.value
   for (const [propertyId, timer] of debounceTimers.entries()) {
     clearTimeout(timer)
     debounceTimers.delete(propertyId)
@@ -1107,7 +1156,7 @@ function flushPendingSaves() {
       || patientProperties.value.find(p => p.property_id === propertyId)
     pendingSaveProps.delete(propertyId)
     if (prop) {
-      persistPropertyDraft(prop, true)
+      void persistPropertyDraft(prop, true, patientId)
     }
   }
 }
@@ -1286,11 +1335,16 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('beforeunload', handleBeforeUnload)
+  flushPendingSaves()
   clearPendingSaves()
   clearSelectedPatientPhoto()
 })
 
-watch(selectedPatientId, () => {
+watch(selectedPatientId, (newId, oldId) => {
+  // Flush debounced edits for the previous patient before wiping local drafts.
+  if (oldId) {
+    flushPendingSaves(oldId)
+  }
   clearPendingSaves()
   activeChartTab.value = 'summary'
   loadSelectedPatientPhoto()

--- a/src/views/PatientsView.vue
+++ b/src/views/PatientsView.vue
@@ -885,16 +885,19 @@ async function loadSelectedPatientPhoto() {
   clearSelectedPatientPhoto()
   const patient = selectedPatient.value
   if (!patient?.has_profile_photo) return
+  const patientId = patient.id
 
   const token = localStorage.getItem('sessionToken')
   if (!token) return
 
   try {
-    const response = await fetch(`/api/patients/${patient.id}/profile-photo`, {
+    const response = await fetch(`/api/patients/${patientId}/profile-photo`, {
       headers: { Authorization: `Bearer ${token}` },
     })
+    if (selectedPatientId.value !== patientId) return
     if (!response.ok) return
     const blob = await response.blob()
+    if (selectedPatientId.value !== patientId) return
     selectedPatientPhotoUrl.value = URL.createObjectURL(blob)
   } catch (error) {
     console.error('Failed to load patient profile photo:', error)
@@ -1223,7 +1226,8 @@ async function loadPatients() {
 }
 
 async function loadProperties() {
-  if (!selectedPatientId.value) {
+  const patientId = selectedPatientId.value
+  if (!patientId) {
     patientProperties.value = []
     return
   }
@@ -1232,7 +1236,8 @@ async function loadProperties() {
   propertiesLoading.value = true
   propertiesError.value = ''
   try {
-    const response = await patientPropertiesApi.list(selectedPatientId.value)
+    const response = await patientPropertiesApi.list(patientId)
+    if (selectedPatientId.value !== patientId) return
 
     if (handleApiAuthFailure(response.error)) {
       return
@@ -1247,9 +1252,13 @@ async function loadProperties() {
     expandedProperties.value = new Set()
   } catch (err) {
     console.error('Failed to load properties:', err)
-    propertiesError.value = 'Failed to load properties'
+    if (selectedPatientId.value === patientId) {
+      propertiesError.value = 'Failed to load properties'
+    }
   } finally {
-    propertiesLoading.value = false
+    if (selectedPatientId.value === patientId) {
+      propertiesLoading.value = false
+    }
   }
 }
 
@@ -1367,7 +1376,8 @@ watch(activeChartTab, (tab) => {
 
 // Document functions
 async function loadDocuments() {
-  if (!selectedPatientId.value) {
+  const patientId = selectedPatientId.value
+  if (!patientId) {
     documents.value = []
     return
   }
@@ -1375,11 +1385,12 @@ async function loadDocuments() {
   documentsLoading.value = true
   documentsError.value = ''
   try {
-    const response = await fetch(`/api/documents/${selectedPatientId.value}`, {
+    const response = await fetch(`/api/documents/${patientId}`, {
       headers: {
         'Authorization': `Bearer ${localStorage.getItem('sessionToken')}`
       }
     })
+    if (selectedPatientId.value !== patientId) return
 
     if (await handleAuthFailure(response)) {
       return
@@ -1391,12 +1402,17 @@ async function loadDocuments() {
     }
 
     const data = await response.json()
+    if (selectedPatientId.value !== patientId) return
     documents.value = data.documents || []
   } catch (err) {
     console.error('Failed to load documents:', err)
-    documentsError.value = 'Failed to load documents'
+    if (selectedPatientId.value === patientId) {
+      documentsError.value = 'Failed to load documents'
+    }
   } finally {
-    documentsLoading.value = false
+    if (selectedPatientId.value === patientId) {
+      documentsLoading.value = false
+    }
   }
 }
 
@@ -1581,14 +1597,16 @@ function formatFileSize(bytes: number): string {
 }
 
 async function loadChartSummary() {
-  if (!selectedPatientId.value) {
+  const patientId = selectedPatientId.value
+  if (!patientId) {
     chartSummary.value = null
     return
   }
   summaryLoading.value = true
   summaryError.value = ''
   try {
-    const result = await chartApi.getSummary(selectedPatientId.value)
+    const result = await chartApi.getSummary(patientId)
+    if (selectedPatientId.value !== patientId) return
     if (result.error) {
       summaryError.value = result.error
       return
@@ -1596,21 +1614,27 @@ async function loadChartSummary() {
     chartSummary.value = result.data?.summary || null
   } catch (err) {
     console.error('Failed to load chart summary:', err)
-    summaryError.value = 'Failed to load chart summary'
+    if (selectedPatientId.value === patientId) {
+      summaryError.value = 'Failed to load chart summary'
+    }
   } finally {
-    summaryLoading.value = false
+    if (selectedPatientId.value === patientId) {
+      summaryLoading.value = false
+    }
   }
 }
 
 async function loadAllergies() {
-  if (!selectedPatientId.value) {
+  const patientId = selectedPatientId.value
+  if (!patientId) {
     allergies.value = []
     return
   }
   allergiesLoading.value = true
   allergiesError.value = ''
   try {
-    const result = await chartApi.listAllergies(selectedPatientId.value)
+    const result = await chartApi.listAllergies(patientId)
+    if (selectedPatientId.value !== patientId) return
     if (result.error) {
       allergiesError.value = result.error
       return
@@ -1618,9 +1642,13 @@ async function loadAllergies() {
     allergies.value = result.data?.allergies || []
   } catch (err) {
     console.error('Failed to load allergies:', err)
-    allergiesError.value = 'Failed to load allergies'
+    if (selectedPatientId.value === patientId) {
+      allergiesError.value = 'Failed to load allergies'
+    }
   } finally {
-    allergiesLoading.value = false
+    if (selectedPatientId.value === patientId) {
+      allergiesLoading.value = false
+    }
   }
 }
 
@@ -1701,14 +1729,16 @@ async function deleteAllergy() {
 }
 
 async function loadMedications() {
-  if (!selectedPatientId.value) {
+  const patientId = selectedPatientId.value
+  if (!patientId) {
     medications.value = []
     return
   }
   medicationsLoading.value = true
   medicationsError.value = ''
   try {
-    const result = await chartApi.listMedications(selectedPatientId.value)
+    const result = await chartApi.listMedications(patientId)
+    if (selectedPatientId.value !== patientId) return
     if (result.error) {
       medicationsError.value = result.error
       return
@@ -1716,9 +1746,13 @@ async function loadMedications() {
     medications.value = result.data?.medications || []
   } catch (err) {
     console.error('Failed to load medications:', err)
-    medicationsError.value = 'Failed to load medications'
+    if (selectedPatientId.value === patientId) {
+      medicationsError.value = 'Failed to load medications'
+    }
   } finally {
-    medicationsLoading.value = false
+    if (selectedPatientId.value === patientId) {
+      medicationsLoading.value = false
+    }
   }
 }
 
@@ -1808,14 +1842,16 @@ async function deleteMedication() {
 }
 
 async function loadProblems() {
-  if (!selectedPatientId.value) {
+  const patientId = selectedPatientId.value
+  if (!patientId) {
     problems.value = []
     return
   }
   problemsLoading.value = true
   problemsError.value = ''
   try {
-    const result = await chartApi.listProblems(selectedPatientId.value)
+    const result = await chartApi.listProblems(patientId)
+    if (selectedPatientId.value !== patientId) return
     if (result.error) {
       problemsError.value = result.error
       return
@@ -1823,9 +1859,13 @@ async function loadProblems() {
     problems.value = result.data?.problems || []
   } catch (err) {
     console.error('Failed to load problems:', err)
-    problemsError.value = 'Failed to load problems'
+    if (selectedPatientId.value === patientId) {
+      problemsError.value = 'Failed to load problems'
+    }
   } finally {
-    problemsLoading.value = false
+    if (selectedPatientId.value === patientId) {
+      problemsLoading.value = false
+    }
   }
 }
 

--- a/src/views/ProviderDashboard.spec.ts
+++ b/src/views/ProviderDashboard.spec.ts
@@ -277,6 +277,79 @@ describe('ProviderDashboard.vue', () => {
     expect(block.attributes('style')).toContain('height: 936px')
   })
 
+  it('does not squeeze timed appointments when an all-day event is present', async () => {
+    const today = getLocalDateString(new Date())
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        doctors: [{ id: 'doc-1', first_name: 'Alice', last_name: 'Smith' }],
+        events: [
+          {
+            id: 'all-day',
+            doctor_id: 'doc-1',
+            event_type: 'meeting',
+            title: 'Clinic Closed',
+            event_date: today,
+            color: '#f59e0b',
+            is_all_day: true,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'timed-a',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Patient A',
+            patient_name: 'Patient A',
+            event_date: today,
+            start_time: '09:00:00',
+            end_time: '09:30:00',
+            color: '#3b82f6',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          },
+          {
+            id: 'timed-b',
+            doctor_id: 'doc-1',
+            event_type: 'appointment',
+            title: 'Patient B',
+            patient_name: 'Patient B',
+            event_date: today,
+            start_time: '11:00:00',
+            end_time: '11:30:00',
+            color: '#10b981',
+            is_all_day: false,
+            provider_name: 'Alice Smith',
+            is_own_event: true,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z'
+          }
+        ]
+      })
+    )
+
+    const wrapper = mount(ProviderDashboard)
+    await flushPromises()
+
+    const allDay = wrapper.find('.schedule-block--all-day')
+    expect(allDay.exists()).toBe(true)
+    expect(allDay.attributes('style')).toContain('width: calc(100% - 4px)')
+
+    const timedBlocks = wrapper
+      .findAll('.schedule-block')
+      .filter((block) => !block.classes().includes('schedule-block--all-day'))
+    expect(timedBlocks.length).toBe(2)
+    for (const block of timedBlocks) {
+      expect(block.attributes('style')).toContain('width: calc(100% - 4px)')
+      expect(block.attributes('style')).toContain('left: calc(0% + 2px)')
+    }
+  })
+
   it('lays overlapping events into side-by-side lanes', async () => {
     const today = getLocalDateString(new Date())
     vi.stubGlobal(

--- a/src/views/ProviderDashboard.vue
+++ b/src/views/ProviderDashboard.vue
@@ -599,6 +599,23 @@ function layoutProviderEvents(providerEvents: DashboardEvent[]): LaidOutEvent[] 
     return []
   }
 
+  // All-day events render full-width behind timed blocks and must not
+  // participate in overlap clustering (they would collapse every lane).
+  const allDayLayouts: LaidOutEvent[] = visible
+    .filter((item) => item.event.is_all_day)
+    .map((item) => ({
+      event: item.event,
+      lane: 0,
+      laneCount: 1,
+      visibleStart: item.visibleStart,
+      visibleEnd: item.visibleEnd
+    }))
+
+  const timed = visible.filter((item) => !item.event.is_all_day)
+  if (timed.length === 0) {
+    return allDayLayouts
+  }
+
   const laneEnds: number[] = []
   const provisional: Array<{
     event: DashboardEvent
@@ -607,7 +624,7 @@ function layoutProviderEvents(providerEvents: DashboardEvent[]): LaidOutEvent[] 
     lane: number
   }> = []
 
-  for (const item of visible) {
+  for (const item of timed) {
     let lane = laneEnds.findIndex((end) => end <= item.visibleStart)
     if (lane === -1) {
       lane = laneEnds.length
@@ -619,7 +636,7 @@ function layoutProviderEvents(providerEvents: DashboardEvent[]): LaidOutEvent[] 
   }
 
   // Within each overlapping cluster, laneCount is the max lane index + 1.
-  return provisional.map((item) => {
+  const timedLayouts = provisional.map((item) => {
     const cluster = new Set<string>([item.event.id])
     let changed = true
     while (changed) {
@@ -658,6 +675,8 @@ function layoutProviderEvents(providerEvents: DashboardEvent[]): LaidOutEvent[] 
       visibleEnd: item.visibleEnd
     }
   })
+
+  return [...allDayLayouts, ...timedLayouts]
 }
 
 function getEventTimeLabel(event: DashboardEvent): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the blocking and important findings from the Code Review on [#37](https://github.com/nhudson99/HHS-patient-portal/pull/37) (Release 2.0 / `develop` → `main`).

### Blocking
1. **Messaging PHI boundary** — Channels now allow at most one patient (create + add-participants). API tests cover create-with-two-patients and add-second-patient rejection; UI compose/add-people also guards.
2. **`patient_visible` legacy backfill** — One-time `schema_migrations` backfill restores pre-flag documents as patient-visible (excluding profile photos; preserves seeded provider-only sample). New uploads still default to `FALSE`.
3. **All-day schedule lanes** — All-day events are excluded from overlap lane packing and render full-width behind timed blocks. Regression spec added.
4. **Patient notes autosave** — Pending drafts flush on patient switch / unmount; save responses no longer clobber newer local keystrokes.

### Important
5. **Profile photos** — Generic rename / visibility / delete return 404 for `document_type = 'profile_photo'`.
6. **Visibility audit** — Toggling `patient_visible` writes an audit event with old/new values.
7. **Message send race** — Top-level and thread sends ignore UI updates if the open conversation/thread changed mid-flight.
8. **Auth fail-closed** — `ALTER TABLE users ADD COLUMN IF NOT EXISTS …` for lockout/`is_active` columns; login/session middleware return 503 instead of weakening controls when columns are missing.
9. **Patient-switch chart race** — Photo/properties/documents/chart loaders ignore stale responses after the selected patient changes.

## Test plan
- [x] Frontend: `ProviderDashboard.spec.ts` (9/9) including all-day + timed full-width regression
- [x] Backend: full `api/tests` suite (35/35), including new channel patient-limit and profile-photo mutation tests
- [ ] Manual: create channel with 2 patients → rejected; notes autosave survives patient switch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ee31b7c-b379-4914-ad3e-02c1339fb6ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ee31b7c-b379-4914-ad3e-02c1339fb6ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

