### PR TITLE
Fix kiosk front-camera capture during check-in

### DIFF
--- a/docker/nginx.azure.conf.template
+++ b/docker/nginx.azure.conf.template
@@ -4,6 +4,9 @@ server {
 
     client_max_body_size 20M;
 
+    # Allow getUserMedia for the kiosk profile-photo step (same-origin only).
+    add_header Permissions-Policy "camera=(self), microphone=()" always;
+
     location /api/ {
         proxy_pass ${API_UPSTREAM};
         proxy_http_version 1.1;
@@ -17,11 +20,13 @@ server {
     location /health {
         return 200 'ok';
         add_header Content-Type text/plain;
+        add_header Permissions-Policy "camera=(self), microphone=()" always;
     }
 
     location / {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;
+        add_header Permissions-Policy "camera=(self), microphone=()" always;
     }
 
     # Always revalidate HTML so clients pick up latest JS bundle references.
@@ -30,6 +35,7 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+        add_header Permissions-Policy "camera=(self), microphone=()" always;
     }
 
     location ~* \.html$ {
@@ -37,12 +43,14 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
+        add_header Permissions-Policy "camera=(self), microphone=()" always;
     }
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         root /usr/share/nginx/html;
         expires 30d;
         add_header Cache-Control "public, immutable";
+        add_header Permissions-Policy "camera=(self), microphone=()" always;
         access_log off;
     }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,6 +46,9 @@ http {
         listen 80;
         server_name _;
 
+        # Allow getUserMedia for the kiosk profile-photo step (same-origin only).
+        add_header Permissions-Policy "camera=(self), microphone=()" always;
+
         # API endpoints
         location /api/ {
             limit_req zone=api_limit burst=20 nodelay;
@@ -86,6 +89,7 @@ http {
         location / {
             root /usr/share/nginx/html;
             try_files $uri $uri/ /index.html;
+            add_header Permissions-Policy "camera=(self), microphone=()" always;
         }
 
         # Always revalidate HTML so new deploys load current JS bundles.
@@ -94,6 +98,7 @@ http {
             add_header Cache-Control "no-store, no-cache, must-revalidate" always;
             add_header Pragma "no-cache" always;
             add_header Expires "0" always;
+            add_header Permissions-Policy "camera=(self), microphone=()" always;
         }
 
         location ~* \.html$ {
@@ -101,6 +106,7 @@ http {
             add_header Cache-Control "no-store, no-cache, must-revalidate" always;
             add_header Pragma "no-cache" always;
             add_header Expires "0" always;
+            add_header Permissions-Policy "camera=(self), microphone=()" always;
         }
 
         # Cache static assets

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -203,7 +203,7 @@ WHERE NOT EXISTS (
 
 -- Keep at least one upcoming appointment available for kiosk check-in / camera testing.
 INSERT INTO appointments (patient_id, doctor_id, appointment_date, reason, notes, status)
-SELECT p.id, d.id, CURRENT_DATE + INTERVAL '1 day' + TIME '10:00', 'Kiosk check-in photo test', 'Seeded relative upcoming visit', 'confirmed'
+SELECT p.id, d.id, NOW() + INTERVAL '1 day', 'Kiosk check-in photo test', 'Seeded relative upcoming visit', 'confirmed'
 FROM users pu
 JOIN patients p ON p.user_id = pu.id
 JOIN users du ON du.username = 'doctor1'

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -201,6 +201,22 @@ WHERE NOT EXISTS (
       AND existing.reason = a.reason
 );
 
+-- Keep at least one upcoming appointment available for kiosk check-in / camera testing.
+INSERT INTO appointments (patient_id, doctor_id, appointment_date, reason, notes, status)
+SELECT p.id, d.id, CURRENT_DATE + INTERVAL '1 day' + TIME '10:00', 'Kiosk check-in photo test', 'Seeded relative upcoming visit', 'confirmed'
+FROM users pu
+JOIN patients p ON p.user_id = pu.id
+JOIN users du ON du.username = 'doctor1'
+JOIN doctors d ON d.user_id = du.id
+WHERE pu.username = 'patient1'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM appointments existing
+    WHERE existing.patient_id = p.id
+      AND existing.reason = 'Kiosk check-in photo test'
+      AND existing.appointment_date::date = (CURRENT_DATE + INTERVAL '1 day')::date
+  );
+
 -- Calendar events across multiple providers and event types.
 INSERT INTO events (
     doctor_id, patient_id, event_type, title, description, event_date,

--- a/src/utils/frontCamera.spec.ts
+++ b/src/utils/frontCamera.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  acquireFrontCameraStream,
+  classifyGetUserMediaError,
+  frontCameraConstraintAttempts,
+  FrontCameraError,
+  isRearFacingStream,
+  isSecureCameraContext,
+  trackFacingMode,
+} from './frontCamera'
+
+function mockStream(facingMode?: string): MediaStream {
+  const track = {
+    readyState: 'live',
+    stop: vi.fn(),
+    getSettings: () => (facingMode ? { facingMode } : {}),
+  }
+  return {
+    getVideoTracks: () => [track],
+    getTracks: () => [track],
+  } as unknown as MediaStream
+}
+
+describe('frontCamera helpers', () => {
+  it('requires a secure context with getUserMedia', () => {
+    expect(isSecureCameraContext(false, { getUserMedia: vi.fn() })).toBe(false)
+    expect(isSecureCameraContext(true, null)).toBe(false)
+    expect(isSecureCameraContext(true, { getUserMedia: vi.fn() })).toBe(true)
+  })
+
+  it('detects rear-facing streams from track settings', () => {
+    expect(trackFacingMode(mockStream('user'))).toBe('user')
+    expect(isRearFacingStream(mockStream('environment'))).toBe(true)
+    expect(isRearFacingStream(mockStream('user'))).toBe(false)
+    expect(isRearFacingStream(mockStream())).toBe(false)
+  })
+
+  it('tries exact user, ideal user, then any video', () => {
+    const attempts = frontCameraConstraintAttempts()
+    expect(attempts).toHaveLength(3)
+    expect(attempts[0]).toEqual({ video: { facingMode: { exact: 'user' } }, audio: false })
+    expect(attempts[1]).toEqual({ video: { facingMode: { ideal: 'user' } }, audio: false })
+    expect(attempts[2]).toEqual({ video: true, audio: false })
+  })
+
+  it('classifies permission errors', () => {
+    expect(classifyGetUserMediaError({ name: 'NotAllowedError' })).toBe('permission')
+    expect(classifyGetUserMediaError({ name: 'OverconstrainedError' })).toBe('unavailable')
+  })
+
+  it('returns the first non-rear stream', async () => {
+    const front = mockStream('user')
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce({ name: 'OverconstrainedError' })
+      .mockResolvedValueOnce(front)
+
+    const stream = await acquireFrontCameraStream(
+      { getUserMedia } as unknown as MediaDevices,
+      { isSecureContext: true },
+    )
+    expect(stream).toBe(front)
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops rear streams and keeps looking', async () => {
+    const rear = mockStream('environment')
+    const front = mockStream('user')
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(rear)
+      .mockResolvedValueOnce(front)
+
+    const stream = await acquireFrontCameraStream(
+      { getUserMedia } as unknown as MediaDevices,
+      { isSecureContext: true },
+    )
+    expect(stream).toBe(front)
+    expect(rear.getTracks()[0].stop).toHaveBeenCalled()
+  })
+
+  it('rejects when only a rear camera is available', async () => {
+    const getUserMedia = vi.fn().mockResolvedValue(mockStream('environment'))
+
+    await expect(
+      acquireFrontCameraStream(
+        { getUserMedia } as unknown as MediaDevices,
+        { isSecureContext: true },
+      ),
+    ).rejects.toMatchObject({ reason: 'rear_only' } satisfies Partial<FrontCameraError>)
+  })
+
+  it('rejects insecure contexts before calling getUserMedia', async () => {
+    const getUserMedia = vi.fn()
+    await expect(
+      acquireFrontCameraStream(
+        { getUserMedia } as unknown as MediaDevices,
+        { isSecureContext: false },
+      ),
+    ).rejects.toMatchObject({ reason: 'insecure' })
+    expect(getUserMedia).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/frontCamera.ts
+++ b/src/utils/frontCamera.ts
@@ -1,0 +1,118 @@
+/**
+ * Helpers for opening the user-facing (front) camera on kiosk tablets.
+ * Prefer facingMode "user"; never keep an environment/rear stream.
+ */
+
+export type FrontCameraFailureReason =
+  | 'unsupported'
+  | 'insecure'
+  | 'permission'
+  | 'unavailable'
+  | 'rear_only'
+
+export class FrontCameraError extends Error {
+  reason: FrontCameraFailureReason
+
+  constructor(reason: FrontCameraFailureReason, message: string) {
+    super(message)
+    this.name = 'FrontCameraError'
+    this.reason = reason
+  }
+}
+
+export function isSecureCameraContext(
+  isSecureContext: boolean,
+  mediaDevices: Pick<MediaDevices, 'getUserMedia'> | null | undefined,
+): boolean {
+  return Boolean(isSecureContext && mediaDevices?.getUserMedia)
+}
+
+export function trackFacingMode(stream: MediaStream): string | undefined {
+  const track = stream.getVideoTracks()[0]
+  if (!track) return undefined
+  const settings = track.getSettings?.() ?? {}
+  return typeof settings.facingMode === 'string' ? settings.facingMode : undefined
+}
+
+/** True when the stream is known to be a rear / world-facing camera. */
+export function isRearFacingStream(stream: MediaStream): boolean {
+  return trackFacingMode(stream) === 'environment'
+}
+
+export function frontCameraConstraintAttempts(): MediaStreamConstraints[] {
+  return [
+    { video: { facingMode: { exact: 'user' } }, audio: false },
+    { video: { facingMode: { ideal: 'user' } }, audio: false },
+    // Some desktop / kiosk WebViews reject facingMode entirely. Open any
+    // camera, then reject the stream if settings report environment.
+    { video: true, audio: false },
+  ]
+}
+
+export function classifyGetUserMediaError(err: unknown): FrontCameraFailureReason {
+  const name = err && typeof err === 'object' && 'name' in err ? String((err as { name: string }).name) : ''
+  if (name === 'NotAllowedError' || name === 'PermissionDeniedError' || name === 'SecurityError') {
+    return 'permission'
+  }
+  if (name === 'NotFoundError' || name === 'DevicesNotFoundError') {
+    return 'unavailable'
+  }
+  if (name === 'OverconstrainedError' || name === 'ConstraintNotSatisfiedError') {
+    return 'unavailable'
+  }
+  return 'unavailable'
+}
+
+export function frontCameraErrorMessage(reason: FrontCameraFailureReason): string {
+  switch (reason) {
+    case 'insecure':
+      return 'Camera requires a secure connection (HTTPS or localhost).'
+    case 'unsupported':
+      return 'Camera is not supported in this browser.'
+    case 'permission':
+      return 'Camera permission was denied. Tap Enable Camera to try again, or skip.'
+    case 'rear_only':
+      return 'Front camera is not available on this device.'
+    default:
+      return 'Unable to open the front camera. Tap Enable Camera to try again, or skip.'
+  }
+}
+
+/**
+ * Acquire a front-facing MediaStream. Stops and discards rear-camera streams.
+ * Call during a user gesture when possible (iOS / Safari kiosk browsers).
+ */
+export async function acquireFrontCameraStream(
+  mediaDevices: MediaDevices,
+  options: { isSecureContext: boolean } = { isSecureContext: true },
+): Promise<MediaStream> {
+  if (!options.isSecureContext) {
+    throw new FrontCameraError('insecure', frontCameraErrorMessage('insecure'))
+  }
+  if (!mediaDevices?.getUserMedia) {
+    throw new FrontCameraError('unsupported', frontCameraErrorMessage('unsupported'))
+  }
+
+  let lastReason: FrontCameraFailureReason = 'unavailable'
+  let sawRearOnly = false
+
+  for (const constraints of frontCameraConstraintAttempts()) {
+    try {
+      const stream = await mediaDevices.getUserMedia(constraints)
+      if (isRearFacingStream(stream)) {
+        for (const track of stream.getTracks()) track.stop()
+        sawRearOnly = true
+        lastReason = 'rear_only'
+        continue
+      }
+      return stream
+    } catch (err) {
+      lastReason = classifyGetUserMediaError(err)
+    }
+  }
+
+  if (sawRearOnly && lastReason === 'rear_only') {
+    throw new FrontCameraError('rear_only', frontCameraErrorMessage('rear_only'))
+  }
+  throw new FrontCameraError(lastReason, frontCameraErrorMessage(lastReason))
+}

--- a/src/views/KioskView.spec.ts
+++ b/src/views/KioskView.spec.ts
@@ -14,9 +14,41 @@ function mockStream(): MediaStream {
   } as unknown as MediaStream
 }
 
+function stubVideoPreview() {
+  Object.defineProperty(HTMLVideoElement.prototype, 'srcObject', {
+    configurable: true,
+    get() {
+      return (this as HTMLVideoElement & { _srcObject?: MediaStream | null })._srcObject ?? null
+    },
+    set(value: MediaStream | null) {
+      ;(this as HTMLVideoElement & { _srcObject?: MediaStream | null })._srcObject = value
+    },
+  })
+  Object.defineProperty(HTMLVideoElement.prototype, 'videoWidth', {
+    configurable: true,
+    get() {
+      return (this as HTMLVideoElement).srcObject ? 640 : 0
+    },
+  })
+  Object.defineProperty(HTMLVideoElement.prototype, 'videoHeight', {
+    configurable: true,
+    get() {
+      return (this as HTMLVideoElement).srcObject ? 480 : 0
+    },
+  })
+  Object.defineProperty(HTMLVideoElement.prototype, 'readyState', {
+    configurable: true,
+    get() {
+      return (this as HTMLVideoElement).srcObject ? 4 : 0
+    },
+  })
+  HTMLVideoElement.prototype.play = vi.fn().mockResolvedValue(undefined)
+}
+
 describe('KioskView camera step', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    stubVideoPreview()
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
@@ -34,6 +66,9 @@ describe('KioskView camera step', () => {
               },
             }),
           }
+        }
+        if (url.includes('/checkin-guest') || url.includes('/profile-photo/kiosk')) {
+          return { ok: true, json: async () => ({}) }
         }
         return { ok: true, json: async () => ({}) }
       }),
@@ -107,5 +142,46 @@ describe('KioskView camera step', () => {
     resolveLookup(undefined)
     await flushPromises()
     expect(wrapper.text()).toContain('Update Profile Photo')
+  })
+
+  it('shows a live video preview and Capture Photo before check-in completes', async () => {
+    const stream = mockStream()
+    const getUserMedia = vi.fn().mockResolvedValue(stream)
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia },
+    })
+    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
+
+    const wrapper = mount(KioskView)
+    await wrapper.get('.kiosk-btn.primary.big').trigger('click')
+    await wrapper.get('#fullName').setValue('John Smith')
+    await wrapper.get('#dob').setValue('1990-05-15')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('Capture Photo')
+    })
+
+    const video = wrapper.get('video.camera-preview')
+    expect(video.isVisible()).toBe(true)
+    expect(wrapper.text()).toContain('live preview')
+    expect(wrapper.text()).not.toContain("You're Checked In!")
+    expect(getUserMedia).toHaveBeenCalled()
+
+    // Capture keeps the patient on review — check-in happens only after Use Photo
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
+      drawImage: vi.fn(),
+    }) as unknown as typeof HTMLCanvasElement.prototype.getContext
+    HTMLCanvasElement.prototype.toDataURL = vi.fn().mockReturnValue(
+      'data:image/jpeg;base64,/9j/4AAQ',
+    )
+    HTMLCanvasElement.prototype.toBlob = vi.fn((cb: BlobCallback) => {
+      cb(new Blob(['fake-jpeg'], { type: 'image/jpeg' }))
+    }) as unknown as typeof HTMLCanvasElement.prototype.toBlob
+
+    await wrapper.get('button.kiosk-btn.primary').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Use Photo & Check In')
+    expect(wrapper.text()).not.toContain("You're Checked In!")
   })
 })

--- a/src/views/KioskView.spec.ts
+++ b/src/views/KioskView.spec.ts
@@ -1,0 +1,111 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import KioskView from '@/views/KioskView.vue'
+
+function mockStream(): MediaStream {
+  const track = {
+    readyState: 'live',
+    stop: vi.fn(),
+    getSettings: () => ({ facingMode: 'user' }),
+  }
+  return {
+    getVideoTracks: () => [track],
+    getTracks: () => [track],
+  } as unknown as MediaStream
+}
+
+describe('KioskView camera step', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/appointments/kiosk/lookup')) {
+          return {
+            ok: true,
+            json: async () => ({
+              appointment: {
+                id: 'apt-1',
+                patient_id: 'pat-1',
+                appointment_date: '2026-08-01T10:00:00.000Z',
+                doctor_name: 'Adams',
+                reason: 'Follow-up',
+              },
+            }),
+          }
+        }
+        return { ok: true, json: async () => ({}) }
+      }),
+    )
+  })
+
+  it('stays on the photo step with Enable Camera when getUserMedia fails', async () => {
+    const getUserMedia = vi.fn().mockRejectedValue({ name: 'NotAllowedError' })
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia },
+    })
+    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
+
+    const wrapper = mount(KioskView)
+    await wrapper.get('.kiosk-btn.primary.big').trigger('click')
+    await wrapper.get('#fullName').setValue('John Smith')
+    await wrapper.get('#dob').setValue('1990-05-15')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Update Profile Photo')
+    expect(wrapper.text()).toContain('Enable Camera')
+    expect(wrapper.text()).toMatch(/permission was denied|Unable to open the front camera|Front camera/i)
+    expect(wrapper.text()).not.toContain("You're Checked In!")
+  })
+
+  it('starts getUserMedia during the Check In click before lookup resolves', async () => {
+    let resolveLookup: (value: unknown) => void = () => undefined
+    const lookupGate = new Promise((resolve) => {
+      resolveLookup = resolve
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/appointments/kiosk/lookup')) {
+          await lookupGate
+          return {
+            ok: true,
+            json: async () => ({
+              appointment: {
+                id: 'apt-1',
+                patient_id: 'pat-1',
+                appointment_date: '2026-08-01T10:00:00.000Z',
+                doctor_name: 'Adams',
+                reason: 'Follow-up',
+              },
+            }),
+          }
+        }
+        return { ok: true, json: async () => ({}) }
+      }),
+    )
+
+    const getUserMedia = vi.fn().mockResolvedValue(mockStream())
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia },
+    })
+    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
+
+    const wrapper = mount(KioskView)
+    await wrapper.get('.kiosk-btn.primary.big').trigger('click')
+    await wrapper.get('#fullName').setValue('John Smith')
+    await wrapper.get('#dob').setValue('1990-05-15')
+    await wrapper.get('form').trigger('submit')
+
+    // Camera request must start before lookup finishes (user-gesture window).
+    expect(getUserMedia).toHaveBeenCalled()
+
+    resolveLookup(undefined)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Update Profile Photo')
+  })
+})

--- a/src/views/KioskView.spec.ts
+++ b/src/views/KioskView.spec.ts
@@ -45,7 +45,22 @@ function stubVideoPreview() {
   HTMLVideoElement.prototype.play = vi.fn().mockResolvedValue(undefined)
 }
 
-describe('KioskView camera step', () => {
+function appointmentResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      appointment: {
+        id: 'apt-1',
+        patient_id: 'pat-1',
+        appointment_date: '2026-08-01T10:00:00.000Z',
+        doctor_name: 'Adams',
+        reason: 'Follow-up',
+      },
+    }),
+  }
+}
+
+describe('KioskView camera-first check-in', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     stubVideoPreview()
@@ -54,18 +69,7 @@ describe('KioskView camera step', () => {
       vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input)
         if (url.includes('/api/appointments/kiosk/lookup')) {
-          return {
-            ok: true,
-            json: async () => ({
-              appointment: {
-                id: 'apt-1',
-                patient_id: 'pat-1',
-                appointment_date: '2026-08-01T10:00:00.000Z',
-                doctor_name: 'Adams',
-                reason: 'Follow-up',
-              },
-            }),
-          }
+          return appointmentResponse()
         }
         if (url.includes('/checkin-guest') || url.includes('/profile-photo/kiosk')) {
           return { ok: true, json: async () => ({}) }
@@ -75,27 +79,15 @@ describe('KioskView camera step', () => {
     )
   })
 
-  it('stays on the photo step with Enable Camera when getUserMedia fails', async () => {
-    const getUserMedia = vi.fn().mockRejectedValue({ name: 'NotAllowedError' })
-    vi.stubGlobal('navigator', {
-      mediaDevices: { getUserMedia },
-    })
-    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
-
-    const wrapper = mount(KioskView)
+  async function submitForm(wrapper: ReturnType<typeof mount>) {
     await wrapper.get('.kiosk-btn.primary.big').trigger('click')
     await wrapper.get('#fullName').setValue('John Smith')
     await wrapper.get('#dob').setValue('1990-05-15')
     await wrapper.get('form').trigger('submit')
     await flushPromises()
+  }
 
-    expect(wrapper.text()).toContain('Update Profile Photo')
-    expect(wrapper.text()).toContain('Enable Camera')
-    expect(wrapper.text()).toMatch(/permission was denied|Unable to open the front camera|Front camera/i)
-    expect(wrapper.text()).not.toContain("You're Checked In!")
-  })
-
-  it('starts getUserMedia during the Check In click before lookup resolves', async () => {
+  it('goes straight to the camera preview after Check In, even before lookup finishes', async () => {
     let resolveLookup: (value: unknown) => void = () => undefined
     const lookupGate = new Promise((resolve) => {
       resolveLookup = resolve
@@ -107,18 +99,7 @@ describe('KioskView camera step', () => {
         const url = String(input)
         if (url.includes('/api/appointments/kiosk/lookup')) {
           await lookupGate
-          return {
-            ok: true,
-            json: async () => ({
-              appointment: {
-                id: 'apt-1',
-                patient_id: 'pat-1',
-                appointment_date: '2026-08-01T10:00:00.000Z',
-                doctor_name: 'Adams',
-                reason: 'Follow-up',
-              },
-            }),
-          }
+          return appointmentResponse()
         }
         return { ok: true, json: async () => ({}) }
       }),
@@ -136,52 +117,87 @@ describe('KioskView camera step', () => {
     await wrapper.get('#dob').setValue('1990-05-15')
     await wrapper.get('form').trigger('submit')
 
-    // Camera request must start before lookup finishes (user-gesture window).
+    // Photo screen appears immediately — not gated on lookup
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('Profile Photo')
+    })
     expect(getUserMedia).toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain("You're Checked In!")
 
     resolveLookup(undefined)
     await flushPromises()
-    expect(wrapper.text()).toContain('Update Profile Photo')
+    expect(wrapper.text()).toContain('Profile Photo')
   })
 
-  it('shows a live video preview and Capture Photo before check-in completes', async () => {
-    const stream = mockStream()
-    const getUserMedia = vi.fn().mockResolvedValue(stream)
+  it('shows Enable Camera + Skip when getUserMedia fails, without auto check-in', async () => {
+    const getUserMedia = vi.fn().mockRejectedValue({ name: 'NotAllowedError' })
     vi.stubGlobal('navigator', {
       mediaDevices: { getUserMedia },
     })
     Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
 
     const wrapper = mount(KioskView)
-    await wrapper.get('.kiosk-btn.primary.big').trigger('click')
-    await wrapper.get('#fullName').setValue('John Smith')
-    await wrapper.get('#dob').setValue('1990-05-15')
-    await wrapper.get('form').trigger('submit')
-    await flushPromises()
-    await vi.waitFor(() => {
-      expect(wrapper.text()).toContain('Capture Photo')
-    })
+    await submitForm(wrapper)
 
-    const video = wrapper.get('video.camera-preview')
-    expect(video.isVisible()).toBe(true)
-    expect(wrapper.text()).toContain('live preview')
+    expect(wrapper.text()).toContain('Profile Photo')
+    expect(wrapper.text()).toContain('Enable Camera')
+    expect(wrapper.text()).toContain('Skip Photo & Check In')
     expect(wrapper.text()).not.toContain("You're Checked In!")
-    expect(getUserMedia).toHaveBeenCalled()
+  })
 
-    // Capture keeps the patient on review — check-in happens only after Use Photo
+  it('still opens the camera preview when appointment lookup fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes('/api/appointments/kiosk/lookup')) {
+          return { ok: false, json: async () => ({ error: 'not found' }) }
+        }
+        return { ok: true, json: async () => ({}) }
+      }),
+    )
+
+    const getUserMedia = vi.fn().mockResolvedValue(mockStream())
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia },
+    })
+    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
+
+    const wrapper = mount(KioskView)
+    await submitForm(wrapper)
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('Capture & Check In')
+    })
+    expect(wrapper.text()).not.toContain("You're Checked In!")
+  })
+
+  it('captures then goes to the check-in confirmation screen', async () => {
+    const getUserMedia = vi.fn().mockResolvedValue(mockStream())
+    vi.stubGlobal('navigator', {
+      mediaDevices: { getUserMedia },
+    })
+    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
+
     HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
       drawImage: vi.fn(),
     }) as unknown as typeof HTMLCanvasElement.prototype.getContext
-    HTMLCanvasElement.prototype.toDataURL = vi.fn().mockReturnValue(
-      'data:image/jpeg;base64,/9j/4AAQ',
-    )
+    HTMLCanvasElement.prototype.toDataURL = vi.fn().mockReturnValue('data:image/jpeg;base64,/9j/4AAQ')
     HTMLCanvasElement.prototype.toBlob = vi.fn((cb: BlobCallback) => {
       cb(new Blob(['fake-jpeg'], { type: 'image/jpeg' }))
     }) as unknown as typeof HTMLCanvasElement.prototype.toBlob
 
+    const wrapper = mount(KioskView)
+    await submitForm(wrapper)
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('Capture & Check In')
+    })
+
     await wrapper.get('button.kiosk-btn.primary').trigger('click')
     await flushPromises()
-    expect(wrapper.text()).toContain('Use Photo & Check In')
-    expect(wrapper.text()).not.toContain("You're Checked In!")
+
+    expect(wrapper.text()).toContain("You're Checked In!")
+    expect(wrapper.text()).toContain('John Smith')
   })
 })

--- a/src/views/KioskView.vue
+++ b/src/views/KioskView.vue
@@ -18,7 +18,7 @@
       <h2>Patient Check-In</h2>
       <p class="kiosk-instruction">Please enter your full name and date of birth</p>
 
-      <form @submit.prevent="handleLookup" class="kiosk-form">
+      <form @submit.prevent="handleCheckIn" class="kiosk-form">
         <div class="form-group">
           <label for="fullName">Full Name</label>
           <input
@@ -61,18 +61,15 @@
 
     <!-- ── Profile photo capture ── -->
     <div v-else-if="screen === 'photo'" class="kiosk-card photo-card">
-      <h2>Update Profile Photo</h2>
+      <h2>Profile Photo</h2>
       <p class="kiosk-instruction">
-        {{ capturedDataUrl
-          ? 'Review your photo, then use it to finish check-in or retake.'
-          : 'Center your face in the live preview below, then capture a photo before finishing check-in. You can skip this step.' }}
+        Center your face in the preview, then capture a photo to finish check-in. You can skip if the camera is unavailable.
       </p>
 
-      <div class="camera-frame" :class="{ 'has-capture': !!capturedDataUrl }">
+      <div class="camera-frame">
         <!-- Keep <video> laid out (not display:none) while starting — hidden videos
              often never decode frames on tablet browsers, which blanks the preview. -->
         <video
-          v-show="!capturedDataUrl"
           ref="videoEl"
           class="camera-preview mirror"
           autoplay
@@ -80,35 +77,29 @@
           playsinline
           webkit-playsinline
         ></video>
-        <img
-          v-if="capturedDataUrl"
-          :src="capturedDataUrl"
-          alt="Captured profile photo"
-          class="camera-preview"
-        />
         <div
-          v-if="!capturedDataUrl && !cameraReady"
+          v-if="!cameraReady"
           class="camera-placeholder"
           :class="{ error: !!cameraError }"
         >
           <template v-if="cameraError">{{ cameraError }}</template>
           <template v-else>{{ startingCamera ? 'Opening camera…' : 'Starting camera…' }}</template>
         </div>
-        <div v-if="!capturedDataUrl && cameraReady" class="camera-guide" aria-hidden="true">
+        <div v-if="cameraReady" class="camera-guide" aria-hidden="true">
           <span class="camera-guide-ring"></span>
         </div>
         <canvas ref="canvasEl" class="capture-canvas"></canvas>
       </div>
 
-      <div v-if="!capturedDataUrl" class="photo-actions">
+      <div class="photo-actions">
         <button
           v-if="cameraReady"
           type="button"
           class="kiosk-btn primary"
           :disabled="uploading"
-          @click="takePhoto"
+          @click="captureAndCheckIn"
         >
-          Capture Photo
+          {{ uploading ? 'Checking In…' : 'Capture & Check In' }}
         </button>
         <button
           v-else
@@ -119,19 +110,8 @@
         >
           {{ startingCamera ? 'Starting…' : 'Enable Camera' }}
         </button>
-        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
-          Skip Photo
-        </button>
-      </div>
-      <div v-else class="photo-actions">
-        <button type="button" class="kiosk-btn primary" :disabled="uploading || !capturedBlob" @click="usePhoto">
-          {{ uploading ? 'Saving…' : 'Use Photo & Check In' }}
-        </button>
-        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="retakePhoto">
-          Retake
-        </button>
-        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
-          Skip Photo
+        <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipAndCheckIn">
+          {{ uploading ? 'Checking In…' : 'Skip Photo & Check In' }}
         </button>
       </div>
     </div>
@@ -211,6 +191,8 @@ const canvasEl = ref<HTMLCanvasElement | null>(null)
 let mediaStream: MediaStream | null = null
 /** In-flight front-camera request started during the Check In user gesture. */
 let pendingFrontStreamPromise: Promise<MediaStream | null> | null = null
+/** Appointment lookup started when entering the photo step (runs in parallel with camera). */
+let pendingLookupPromise: Promise<any | null> | null = null
 
 // ── Countdown (success screen only) ──────────────────────────────────────────
 const RESET_AFTER_SECS = 10
@@ -284,6 +266,7 @@ function reset() {
   clearInactivityTimer()
   stopCamera()
   clearCapture()
+  pendingLookupPromise = null
   screen.value = 'welcome'
   form.value = { fullName: '', dob: '', appointmentTime: '' }
   appointmentInfo.value = null
@@ -477,14 +460,18 @@ async function startFrontCamera(): Promise<boolean> {
   }
 }
 
-async function openPhotoStep(appointment: any) {
-  appointmentInfo.value = appointment
+async function openPhotoStep() {
   clearCapture()
+  appointmentInfo.value = null
+  cameraError.value = ''
+  cameraReady.value = false
   screen.value = 'photo'
   resetInactivityTimer()
+
+  // Look up the appointment in parallel while the camera preview is shown
+  pendingLookupPromise = lookupAppointment()
+
   await nextTick()
-  // Stay on the photo step even when the camera fails so the patient can
-  // tap Enable Camera (restores user gesture) or Skip — do not auto-check-in.
   await startFrontCamera()
 }
 
@@ -493,16 +480,8 @@ async function retryCamera() {
   await startFrontCamera()
 }
 
-// ── API: look up appointment, then photo step or success ──────────────────────
-async function handleLookup() {
-  loading.value = true
-
+async function lookupAppointment(): Promise<any | null> {
   const patientName = form.value.fullName.trim()
-
-  // Kick off the front camera during this click before any await loses
-  // transient user activation (critical on iPad / Safari kiosk browsers).
-  beginFrontCameraDuringUserGesture()
-
   try {
     const lookupRes = await fetch('/api/appointments/kiosk/lookup', {
       method: 'POST',
@@ -515,33 +494,47 @@ async function handleLookup() {
     })
 
     if (!lookupRes.ok) {
-      stopPendingFrontStream()
-      goToSuccess(patientName, null)
-      return
+      appointmentInfo.value = null
+      return null
     }
 
     const { appointment } = await lookupRes.json()
-    await openPhotoStep(appointment)
+    appointmentInfo.value = appointment
+    return appointment
   } catch (e) {
-    console.error('Kiosk check-in error:', e)
-    stopPendingFrontStream()
-    goToSuccess(patientName, null)
+    console.error('Kiosk lookup error:', e)
+    appointmentInfo.value = null
+    return null
+  }
+}
+
+/**
+ * Check In on the form → go straight to the live camera preview.
+ * Appointment lookup runs in the background; check-in APIs run after
+ * Capture or Skip.
+ */
+async function handleCheckIn() {
+  loading.value = true
+  // Start getUserMedia during this click (user gesture), then show preview.
+  beginFrontCameraDuringUserGesture()
+  try {
+    await openPhotoStep()
   } finally {
     loading.value = false
   }
 }
 
-async function takePhoto() {
+async function captureFrameBlob(): Promise<boolean> {
   const video = videoEl.value
   const canvas = canvasEl.value
-  if (!video || !canvas || !cameraReady.value) return
+  if (!video || !canvas || !cameraReady.value) return false
 
   const width = video.videoWidth || 640
   const height = video.videoHeight || 480
   canvas.width = width
   canvas.height = height
   const ctx = canvas.getContext('2d')
-  if (!ctx) return
+  if (!ctx) return false
 
   // Draw un-mirrored frame (preview is CSS-mirrored only)
   ctx.drawImage(video, 0, 0, width, height)
@@ -552,7 +545,6 @@ async function takePhoto() {
   })
 
   if (!blob) {
-    // Fallback: derive blob from data URL so Use Photo is never enabled without bytes
     try {
       const res = await fetch(dataUrl)
       capturedBlob.value = await res.blob()
@@ -560,29 +552,13 @@ async function takePhoto() {
     } catch (e) {
       console.error('Failed to capture photo blob:', e)
       clearCapture()
-      return
+      return false
     }
   } else {
     capturedBlob.value = blob
     capturedDataUrl.value = dataUrl
   }
-  resetInactivityTimer()
-}
-
-async function retakePhoto() {
-  clearCapture()
-  resetInactivityTimer()
-  if (!mediaStream) {
-    await startFrontCamera()
-  } else {
-    cameraReady.value = true
-    cameraError.value = ''
-    await nextTick()
-    if (videoEl.value && mediaStream) {
-      videoEl.value.srcObject = mediaStream
-      await Promise.resolve(videoEl.value.play()).catch(() => undefined)
-    }
-  }
+  return true
 }
 
 async function uploadCapturedPhoto(appointment: any): Promise<boolean> {
@@ -605,29 +581,48 @@ async function uploadCapturedPhoto(appointment: any): Promise<boolean> {
   }
 }
 
-async function usePhoto() {
-  if (!appointmentInfo.value) return
+async function finalizeCheckIn(withPhoto: boolean) {
   uploading.value = true
+  const patientName = form.value.fullName.trim()
   try {
-    // Upload failure must not block check-in
-    await uploadCapturedPhoto(appointmentInfo.value)
-    await completeCheckIn(appointmentInfo.value)
+    const appointment =
+      appointmentInfo.value ??
+      (pendingLookupPromise ? await pendingLookupPromise : await lookupAppointment())
+    pendingLookupPromise = null
+
+    if (withPhoto && appointment) {
+      // Upload failure must not block check-in
+      await uploadCapturedPhoto(appointment)
+    }
+
+    if (appointment) {
+      await completeCheckIn(appointment)
+    } else {
+      goToSuccess(patientName, null)
+    }
+  } catch (e) {
+    console.error('Kiosk check-in error:', e)
+    goToSuccess(patientName, null)
   } finally {
     uploading.value = false
   }
 }
 
-async function skipPhoto() {
-  if (!appointmentInfo.value) {
-    goToSuccess(form.value.fullName.trim(), null)
+async function captureAndCheckIn() {
+  resetInactivityTimer()
+  const ok = await captureFrameBlob()
+  if (!ok) {
+    cameraError.value = 'Could not capture photo. Try again or skip.'
+    cameraReady.value = Boolean(mediaStream)
     return
   }
-  uploading.value = true
-  try {
-    await completeCheckIn(appointmentInfo.value)
-  } finally {
-    uploading.value = false
-  }
+  await finalizeCheckIn(true)
+}
+
+async function skipAndCheckIn() {
+  resetInactivityTimer()
+  clearCapture()
+  await finalizeCheckIn(false)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/views/KioskView.vue
+++ b/src/views/KioskView.vue
@@ -63,17 +63,22 @@
     <div v-else-if="screen === 'photo'" class="kiosk-card photo-card">
       <h2>Update Profile Photo</h2>
       <p class="kiosk-instruction">
-        Look at the camera and take a photo for your patient profile. You can skip this step.
+        {{ capturedDataUrl
+          ? 'Review your photo, then use it to finish check-in or retake.'
+          : 'Center your face in the live preview below, then capture a photo before finishing check-in. You can skip this step.' }}
       </p>
 
-      <div class="camera-frame">
+      <div class="camera-frame" :class="{ 'has-capture': !!capturedDataUrl }">
+        <!-- Keep <video> laid out (not display:none) while starting — hidden videos
+             often never decode frames on tablet browsers, which blanks the preview. -->
         <video
-          v-show="!capturedDataUrl && cameraReady"
+          v-show="!capturedDataUrl"
           ref="videoEl"
           class="camera-preview mirror"
           autoplay
-          playsinline
           muted
+          playsinline
+          webkit-playsinline
         ></video>
         <img
           v-if="capturedDataUrl"
@@ -81,11 +86,16 @@
           alt="Captured profile photo"
           class="camera-preview"
         />
-        <div v-if="!capturedDataUrl && !cameraReady && !cameraError" class="camera-placeholder">
-          Starting camera…
+        <div
+          v-if="!capturedDataUrl && !cameraReady"
+          class="camera-placeholder"
+          :class="{ error: !!cameraError }"
+        >
+          <template v-if="cameraError">{{ cameraError }}</template>
+          <template v-else>{{ startingCamera ? 'Opening camera…' : 'Starting camera…' }}</template>
         </div>
-        <div v-if="!capturedDataUrl && cameraError" class="camera-placeholder error">
-          {{ cameraError }}
+        <div v-if="!capturedDataUrl && cameraReady" class="camera-guide" aria-hidden="true">
+          <span class="camera-guide-ring"></span>
         </div>
         <canvas ref="canvasEl" class="capture-canvas"></canvas>
       </div>
@@ -98,7 +108,7 @@
           :disabled="uploading"
           @click="takePhoto"
         >
-          Take Photo
+          Capture Photo
         </button>
         <button
           v-else
@@ -110,18 +120,18 @@
           {{ startingCamera ? 'Starting…' : 'Enable Camera' }}
         </button>
         <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
-          Skip
+          Skip Photo
         </button>
       </div>
       <div v-else class="photo-actions">
         <button type="button" class="kiosk-btn primary" :disabled="uploading || !capturedBlob" @click="usePhoto">
-          {{ uploading ? 'Saving…' : 'Use Photo' }}
+          {{ uploading ? 'Saving…' : 'Use Photo & Check In' }}
         </button>
         <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="retakePhoto">
           Retake
         </button>
         <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
-          Skip
+          Skip Photo
         </button>
       </div>
     </div>
@@ -333,35 +343,72 @@ function beginFrontCameraDuringUserGesture() {
   pendingFrontStreamPromise = request
 }
 
-async function waitForVideoFrame(video: HTMLVideoElement): Promise<void> {
-  if (video.readyState >= 2 && video.videoWidth > 0) return
+function videoHasPreviewFrame(video: HTMLVideoElement): boolean {
+  return video.readyState >= 2 && video.videoWidth > 0 && video.videoHeight > 0
+}
 
-  await new Promise<void>((resolve) => {
+async function waitForVideoFrame(video: HTMLVideoElement): Promise<boolean> {
+  if (videoHasPreviewFrame(video)) return true
+
+  return new Promise<boolean>((resolve) => {
     let settled = false
-    const finish = () => {
+    const finish = (ok: boolean) => {
       if (settled) return
       settled = true
-      video.removeEventListener('loadeddata', finish)
-      resolve()
+      video.removeEventListener('loadeddata', onUpdate)
+      video.removeEventListener('loadedmetadata', onUpdate)
+      video.removeEventListener('playing', onUpdate)
+      resolve(ok)
     }
-    video.addEventListener('loadeddata', finish)
-    window.setTimeout(finish, 2000)
+    const onUpdate = () => {
+      if (videoHasPreviewFrame(video)) finish(true)
+    }
+
+    video.addEventListener('loadeddata', onUpdate)
+    video.addEventListener('loadedmetadata', onUpdate)
+    video.addEventListener('playing', onUpdate)
+
+    const maybeRvf = video as HTMLVideoElement & {
+      requestVideoFrameCallback?: (cb: () => void) => number
+    }
+    if (typeof maybeRvf.requestVideoFrameCallback === 'function') {
+      maybeRvf.requestVideoFrameCallback(() => finish(videoHasPreviewFrame(video)))
+    }
+
+    window.setTimeout(() => finish(videoHasPreviewFrame(video)), 4000)
   })
 }
 
 async function attachStreamToVideo(stream: MediaStream): Promise<boolean> {
   mediaStream = stream
+  // Ensure the photo-step <video> is mounted and laid out before attaching.
+  // A display:none video often never produces frames on tablet WebViews.
   await nextTick()
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
   const video = videoEl.value
   if (!video) {
     return false
   }
 
+  video.muted = true
+  video.setAttribute('playsinline', 'true')
+  video.setAttribute('webkit-playsinline', 'true')
   video.srcObject = stream
+
+  // Start playback first so frames can decode, then wait for dimensions.
+  // Promise.resolve covers environments where play() returns void (jsdom).
+  await Promise.resolve(video.play()).catch(() => undefined)
   await waitForVideoFrame(video)
-  await video.play().catch(() => undefined)
+  if (!videoHasPreviewFrame(video) && video.paused) {
+    await Promise.resolve(video.play()).catch(() => undefined)
+    await waitForVideoFrame(video)
+  }
 
   const live = stream.getVideoTracks().some((t) => t.readyState === 'live')
+  // Once the track is live and attached to a laid-out <video>, show the
+  // preview and allow capture. Waiting only on videoWidth caused blank
+  // previews on tablet WebViews that lag metadata while frames still paint.
   cameraReady.value = live
   if (!live) {
     cameraError.value = frontCameraErrorMessage('unavailable')
@@ -533,7 +580,7 @@ async function retakePhoto() {
     await nextTick()
     if (videoEl.value && mediaStream) {
       videoEl.value.srcObject = mediaStream
-      await videoEl.value.play().catch(() => undefined)
+      await Promise.resolve(videoEl.value.play()).catch(() => undefined)
     }
   }
 }
@@ -679,18 +726,24 @@ h2 {
 .camera-frame {
   position: relative;
   width: 100%;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 3 / 4;
+  max-height: min(58vh, 520px);
+  margin-inline: auto;
   background: #0f172a;
-  border-radius: 12px;
+  border-radius: 16px;
   overflow: hidden;
   margin-bottom: 20px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .camera-preview {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
+  background: #0f172a;
 }
 
 .camera-preview.mirror {
@@ -700,6 +753,7 @@ h2 {
 .camera-placeholder {
   position: absolute;
   inset: 0;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -708,10 +762,29 @@ h2 {
   font-size: 1.05rem;
   line-height: 1.45;
   text-align: center;
+  background: #0f172a;
 }
 
 .camera-placeholder.error {
   color: #fecaca;
+}
+
+.camera-guide {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.camera-guide-ring {
+  width: min(68%, 260px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 0 0 9999px rgba(15, 23, 42, 0.28);
 }
 
 .capture-canvas {

--- a/src/views/KioskView.vue
+++ b/src/views/KioskView.vue
@@ -68,7 +68,7 @@
 
       <div class="camera-frame">
         <video
-          v-show="!capturedDataUrl"
+          v-show="!capturedDataUrl && cameraReady"
           ref="videoEl"
           class="camera-preview mirror"
           autoplay
@@ -81,12 +81,33 @@
           alt="Captured profile photo"
           class="camera-preview"
         />
+        <div v-if="!capturedDataUrl && !cameraReady && !cameraError" class="camera-placeholder">
+          Starting camera…
+        </div>
+        <div v-if="!capturedDataUrl && cameraError" class="camera-placeholder error">
+          {{ cameraError }}
+        </div>
         <canvas ref="canvasEl" class="capture-canvas"></canvas>
       </div>
 
       <div v-if="!capturedDataUrl" class="photo-actions">
-        <button type="button" class="kiosk-btn primary" :disabled="!cameraReady || uploading" @click="takePhoto">
+        <button
+          v-if="cameraReady"
+          type="button"
+          class="kiosk-btn primary"
+          :disabled="uploading"
+          @click="takePhoto"
+        >
           Take Photo
+        </button>
+        <button
+          v-else
+          type="button"
+          class="kiosk-btn primary"
+          :disabled="uploading || startingCamera"
+          @click="retryCamera"
+        >
+          {{ startingCamera ? 'Starting…' : 'Enable Camera' }}
         </button>
         <button type="button" class="kiosk-btn secondary" :disabled="uploading" @click="skipPhoto">
           Skip
@@ -151,6 +172,13 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, nextTick } from 'vue'
+import {
+  acquireFrontCameraStream,
+  classifyGetUserMediaError,
+  FrontCameraError,
+  frontCameraErrorMessage,
+  isSecureCameraContext,
+} from '@/utils/frontCamera'
 
 // ── State ─────────────────────────────────────────────────────────────────────
 type Screen = 'welcome' | 'form' | 'photo' | 'success'
@@ -158,9 +186,11 @@ type Screen = 'welcome' | 'form' | 'photo' | 'success'
 const screen = ref<Screen>('welcome')
 const loading = ref(false)
 const uploading = ref(false)
+const startingCamera = ref(false)
 const appointmentInfo = ref<any>(null)
 const checkedInName = ref('')
 const cameraReady = ref(false)
+const cameraError = ref('')
 const capturedDataUrl = ref<string | null>(null)
 const capturedBlob = ref<Blob | null>(null)
 
@@ -169,6 +199,8 @@ const form = ref({ fullName: '', dob: '', appointmentTime: '' })
 const videoEl = ref<HTMLVideoElement | null>(null)
 const canvasEl = ref<HTMLCanvasElement | null>(null)
 let mediaStream: MediaStream | null = null
+/** In-flight front-camera request started during the Check In user gesture. */
+let pendingFrontStreamPromise: Promise<MediaStream | null> | null = null
 
 // ── Countdown (success screen only) ──────────────────────────────────────────
 const RESET_AFTER_SECS = 10
@@ -208,7 +240,17 @@ function clearInactivityTimer() {
   inactivityTimer = null
 }
 
+function stopPendingFrontStream() {
+  const pending = pendingFrontStreamPromise
+  pendingFrontStreamPromise = null
+  if (!pending) return
+  void pending.then((stream) => {
+    stream?.getTracks().forEach((track) => track.stop())
+  })
+}
+
 function stopCamera() {
+  stopPendingFrontStream()
   if (mediaStream) {
     for (const track of mediaStream.getTracks()) {
       track.stop()
@@ -238,6 +280,8 @@ function reset() {
   checkedInName.value = ''
   loading.value = false
   uploading.value = false
+  startingCamera.value = false
+  cameraError.value = ''
 }
 
 function goToSuccess(name: string, appointment: any | null) {
@@ -269,33 +313,121 @@ async function completeCheckIn(appointment: any) {
   }
 }
 
-async function startFrontCamera(): Promise<boolean> {
-  if (!navigator.mediaDevices?.getUserMedia) {
+/**
+ * Begin getUserMedia while the Check In click is still a valid user gesture.
+ * iOS / Safari kiosk browsers often reject camera access after an awaited fetch.
+ */
+function beginFrontCameraDuringUserGesture() {
+  stopPendingFrontStream()
+  if (!isSecureCameraContext(window.isSecureContext, navigator.mediaDevices)) {
+    pendingFrontStreamPromise = Promise.resolve(null)
+    return
+  }
+
+  const request = acquireFrontCameraStream(navigator.mediaDevices, {
+    isSecureContext: window.isSecureContext,
+  })
+    .then((stream) => stream)
+    .catch(() => null)
+
+  pendingFrontStreamPromise = request
+}
+
+async function waitForVideoFrame(video: HTMLVideoElement): Promise<void> {
+  if (video.readyState >= 2 && video.videoWidth > 0) return
+
+  await new Promise<void>((resolve) => {
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      video.removeEventListener('loadeddata', finish)
+      resolve()
+    }
+    video.addEventListener('loadeddata', finish)
+    window.setTimeout(finish, 2000)
+  })
+}
+
+async function attachStreamToVideo(stream: MediaStream): Promise<boolean> {
+  mediaStream = stream
+  await nextTick()
+  const video = videoEl.value
+  if (!video) {
     return false
   }
 
-  // Front-facing only — do not fall back to any/rear camera on dual-camera tablets
-  const attempts: MediaStreamConstraints[] = [
-    { video: { facingMode: { exact: 'user' } }, audio: false },
-    { video: { facingMode: 'user' }, audio: false },
-  ]
+  video.srcObject = stream
+  await waitForVideoFrame(video)
+  await video.play().catch(() => undefined)
 
-  for (const constraints of attempts) {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia(constraints)
-      mediaStream = stream
-      await nextTick()
-      if (videoEl.value) {
-        videoEl.value.srcObject = stream
-        await videoEl.value.play().catch(() => undefined)
-      }
-      cameraReady.value = true
-      return true
-    } catch {
-      // try next front-facing constraint
-    }
+  const live = stream.getVideoTracks().some((t) => t.readyState === 'live')
+  cameraReady.value = live
+  if (!live) {
+    cameraError.value = frontCameraErrorMessage('unavailable')
   }
-  return false
+  return live
+}
+
+async function startFrontCamera(): Promise<boolean> {
+  startingCamera.value = true
+  cameraError.value = ''
+  cameraReady.value = false
+
+  try {
+    if (!isSecureCameraContext(window.isSecureContext, navigator.mediaDevices)) {
+      cameraError.value = frontCameraErrorMessage(
+        window.isSecureContext ? 'unsupported' : 'insecure',
+      )
+      return false
+    }
+
+    // Prefer a stream already opened during the Check In user gesture
+    let stream: MediaStream | null = null
+    if (pendingFrontStreamPromise) {
+      const pending = pendingFrontStreamPromise
+      pendingFrontStreamPromise = null
+      stream = await pending
+      // If the user navigated away while waiting, drop the stream
+      if (screen.value !== 'photo') {
+        stream?.getTracks().forEach((track) => track.stop())
+        return false
+      }
+    }
+
+    if (!stream) {
+      try {
+        stream = await acquireFrontCameraStream(navigator.mediaDevices, {
+          isSecureContext: window.isSecureContext,
+        })
+      } catch (err) {
+        if (err instanceof FrontCameraError) {
+          cameraError.value = err.message
+        } else {
+          cameraError.value = frontCameraErrorMessage(classifyGetUserMediaError(err))
+        }
+        return false
+      }
+    }
+
+    // Stop any previous preview tracks before attaching the new stream
+    if (mediaStream && mediaStream !== stream) {
+      for (const track of mediaStream.getTracks()) track.stop()
+      mediaStream = null
+    }
+
+    const ok = await attachStreamToVideo(stream)
+    if (!ok) {
+      for (const track of stream.getTracks()) track.stop()
+      if (mediaStream === stream) mediaStream = null
+      if (!cameraError.value) {
+        cameraError.value = frontCameraErrorMessage('unavailable')
+      }
+    }
+    return ok
+  } finally {
+    startingCamera.value = false
+  }
 }
 
 async function openPhotoStep(appointment: any) {
@@ -304,11 +436,14 @@ async function openPhotoStep(appointment: any) {
   screen.value = 'photo'
   resetInactivityTimer()
   await nextTick()
-  const ok = await startFrontCamera()
-  if (!ok) {
-    // Auto-skip when camera is unavailable
-    await completeCheckIn(appointment)
-  }
+  // Stay on the photo step even when the camera fails so the patient can
+  // tap Enable Camera (restores user gesture) or Skip — do not auto-check-in.
+  await startFrontCamera()
+}
+
+async function retryCamera() {
+  resetInactivityTimer()
+  await startFrontCamera()
 }
 
 // ── API: look up appointment, then photo step or success ──────────────────────
@@ -316,6 +451,10 @@ async function handleLookup() {
   loading.value = true
 
   const patientName = form.value.fullName.trim()
+
+  // Kick off the front camera during this click before any await loses
+  // transient user activation (critical on iPad / Safari kiosk browsers).
+  beginFrontCameraDuringUserGesture()
 
   try {
     const lookupRes = await fetch('/api/appointments/kiosk/lookup', {
@@ -329,6 +468,7 @@ async function handleLookup() {
     })
 
     if (!lookupRes.ok) {
+      stopPendingFrontStream()
       goToSuccess(patientName, null)
       return
     }
@@ -337,6 +477,7 @@ async function handleLookup() {
     await openPhotoStep(appointment)
   } catch (e) {
     console.error('Kiosk check-in error:', e)
+    stopPendingFrontStream()
     goToSuccess(patientName, null)
   } finally {
     loading.value = false
@@ -385,9 +526,14 @@ async function retakePhoto() {
   clearCapture()
   resetInactivityTimer()
   if (!mediaStream) {
-    const ok = await startFrontCamera()
-    if (!ok) {
-      await skipPhoto()
+    await startFrontCamera()
+  } else {
+    cameraReady.value = true
+    cameraError.value = ''
+    await nextTick()
+    if (videoEl.value && mediaStream) {
+      videoEl.value.srcObject = mediaStream
+      await videoEl.value.play().catch(() => undefined)
     }
   }
 }
@@ -549,6 +695,23 @@ h2 {
 
 .camera-preview.mirror {
   transform: scaleX(-1);
+}
+
+.camera-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: #e2e8f0;
+  font-size: 1.05rem;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.camera-placeholder.error {
+  color: #fecaca;
 }
 
 .capture-canvas {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The kiosk profile-photo step often never showed a working front camera: `getUserMedia` ran only after the appointment lookup `await` (losing iOS/Safari user activation), failures were swallowed and auto-skipped check-in, and removing the `{ video: true }` fallback left devices that reject `facingMode` with no path to open a single front/webcam.

## Changes
- Start front-camera acquisition during the **Check In** click (in parallel with lookup), then attach the stream on the photo step.
- On camera failure, **stay on the photo step** with an error message, **Enable Camera** (restores user gesture), and **Skip** — no silent auto-check-in.
- Shared `frontCamera` helper: try `exact: user` → `ideal: user` → any video, but **discard rear/`environment` streams**.
- Wait for video frames before enabling Take Photo; show a starting/error placeholder in the preview.
- Nginx `Permissions-Policy: camera=(self)` on HTML responses (local + Azure templates).
- Seed an upcoming `patient1` appointment so kiosk lookup can reach the photo step in local testing.
- Vitest coverage for helpers and the non-auto-skip photo-step behavior.

## Testing
- `npm run test:frontend -- src/utils/frontCamera.spec.ts src/views/KioskView.spec.ts`
- `npx vue-tsc --noEmit`
- Manual: `/kiosk` → John Smith / 1990-05-15 → photo step should open front camera (or show Enable Camera / Skip if unavailable).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f198e8-ae54-454c-a5f0-a8f134b61805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f198e8-ae54-454c-a5f0-a8f134b61805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

