### PR TITLE
Fix login session lifecycle and admin user creation

### DIFF
--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -6,10 +6,17 @@ HIPAA Compliance: Ensures only authenticated users can access PHI
 from functools import wraps
 from flask import request, jsonify
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from psycopg2 import errors as pg_errors
 from api.utils.session_manager import validate_session
 from api.db.connection import execute_query
+
+# Endpoints allowed while a password change is required.
+_PASSWORD_CHANGE_ALLOWED_PATHS = {
+    '/api/auth/change-password',
+    '/api/auth/logout',
+    '/api/auth/me',
+}
 
 
 def _schema_not_initialized_response():
@@ -22,6 +29,19 @@ def _comparison_now(reference_dt):
     if reference_dt and reference_dt.tzinfo and reference_dt.tzinfo.utcoffset(reference_dt) is not None:
         return datetime.now(timezone.utc)
     return datetime.now()
+
+
+def _password_change_required(user: dict) -> bool:
+    if user.get('must_change_password'):
+        return True
+
+    password_last_changed = user.get('password_last_changed')
+    if not password_last_changed:
+        return False
+
+    password_expiry_days = int(os.getenv('PASSWORD_EXPIRY_DAYS', 90))
+    expiry_date = password_last_changed + timedelta(days=password_expiry_days)
+    return _comparison_now(expiry_date) > expiry_date
 
 
 def authenticate(f):
@@ -51,7 +71,7 @@ def authenticate(f):
         
         # Get user details — require is_active (fail closed if column missing).
         query = """
-            SELECT id, username, role, email
+            SELECT id, username, role, email, must_change_password, password_last_changed
             FROM users
             WHERE id = %s AND is_active = true
         """
@@ -64,10 +84,23 @@ def authenticate(f):
         
         if not user:
             return jsonify({'error': 'User not found or inactive'}), 401
-        
+
+        user_data = dict(user)
+        require_password_change = _password_change_required(user_data)
+        user_data['requirePasswordChange'] = require_password_change
+        # Keep response payloads tidy — callers use requirePasswordChange.
+        user_data.pop('must_change_password', None)
+        user_data.pop('password_last_changed', None)
+
         # Attach user to request context
-        request.user = dict(user)
+        request.user = user_data
         request.session_token = session_token
+
+        if require_password_change and request.path not in _PASSWORD_CHANGE_ALLOWED_PATHS:
+            return jsonify({
+                'error': 'Password change required',
+                'code': 'PASSWORD_CHANGE_REQUIRED',
+            }), 403
         
         return f(*args, **kwargs)
     

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -27,6 +27,7 @@ from functools import wraps
 import jwt
 from jwt import PyJWKClient, PyJWKClientError
 import bcrypt
+from psycopg2 import errors as pg_errors
 
 from api.db.connection import execute_query, DatabaseTransaction
 
@@ -251,6 +252,32 @@ def _build_password_hash(password: str) -> tuple[str, str]:
     return password_hash, salt
 
 
+def _required_fields(data: dict, fields: list[str]) -> tuple[dict[str, str] | None, str | None]:
+    """Strip required fields; return cleaned map or an error message."""
+    cleaned: dict[str, str] = {}
+    for field in fields:
+        value = _clean_text(data.get(field))
+        if not value:
+            return None, f'Missing required field: {field}'
+        cleaned[field] = value
+    return cleaned, None
+
+
+def _username_or_email_taken(username: str, email: str) -> bool:
+    existing = execute_query(
+        "SELECT id FROM users WHERE username = %s OR email = %s",
+        (username, email),
+        fetch_one=True,
+    )
+    return bool(existing)
+
+
+def _is_unique_violation(exc: BaseException) -> bool:
+    return isinstance(exc, pg_errors.UniqueViolation) or (
+        hasattr(exc, 'pgcode') and getattr(exc, 'pgcode', None) == '23505'
+    )
+
+
 @admin_bp.route('/verify-token', methods=['POST'])
 def verify_token():
     """
@@ -311,50 +338,66 @@ def list_admin_doctors():
 def create_doctor():
     data = request.get_json(silent=True) or {}
     required = ['username', 'email', 'firstName', 'lastName', 'specialty', 'licenseNumber']
-    if not all(data.get(field) for field in required):
-        return jsonify({'error': 'Missing required provider fields'}), 400
+    cleaned, field_error = _required_fields(data, required)
+    if field_error:
+        return jsonify({'error': field_error}), 400
+
+    username = cleaned['username']
+    email = cleaned['email'].lower()
+    is_active = bool(data.get('isActive', True))
+
+    if _username_or_email_taken(username, email):
+        return jsonify({'error': 'Username or email already in use'}), 409
 
     temp_password = _generate_temp_password()
     password_hash, salt = _build_password_hash(temp_password)
 
-    with DatabaseTransaction() as cursor:
-        cursor.execute(
-            """
-            INSERT INTO users (username, email, password_hash, salt, role, must_change_password)
-            VALUES (%s, %s, %s, %s, 'doctor', true)
-            RETURNING id, username, email, role
-            """,
-            (data['username'].strip(), data['email'].strip().lower(), password_hash, salt),
-        )
-        user = cursor.fetchone()
-
-        cursor.execute(
-            """
-            INSERT INTO doctors (
-                user_id, first_name, last_name, specialty, license_number,
-                license_state, phone, office_address
+    try:
+        with DatabaseTransaction() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO users (
+                    username, email, password_hash, salt, role,
+                    must_change_password, is_active
+                )
+                VALUES (%s, %s, %s, %s, 'doctor', true, %s)
+                RETURNING id, username, email, role, is_active
+                """,
+                (username, email, password_hash, salt, is_active),
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-            RETURNING id, user_id, first_name, last_name, specialty, license_number,
-                      license_state, phone, office_address, created_at, updated_at
-            """,
-            (
-                user['id'],
-                data['firstName'].strip(),
-                data['lastName'].strip(),
-                data['specialty'].strip(),
-                data['licenseNumber'].strip(),
-                (data.get('licenseState') or '').strip() or None,
-                (data.get('phone') or '').strip() or None,
-                (data.get('officeAddress') or '').strip() or None,
-            ),
-        )
-        doctor = cursor.fetchone()
+            user = cursor.fetchone()
+
+            cursor.execute(
+                """
+                INSERT INTO doctors (
+                    user_id, first_name, last_name, specialty, license_number,
+                    license_state, phone, office_address
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id, user_id, first_name, last_name, specialty, license_number,
+                          license_state, phone, office_address, created_at, updated_at
+                """,
+                (
+                    user['id'],
+                    cleaned['firstName'],
+                    cleaned['lastName'],
+                    cleaned['specialty'],
+                    cleaned['licenseNumber'],
+                    (data.get('licenseState') or '').strip() or None,
+                    (data.get('phone') or '').strip() or None,
+                    (data.get('officeAddress') or '').strip() or None,
+                ),
+            )
+            doctor = cursor.fetchone()
+    except Exception as exc:
+        if _is_unique_violation(exc):
+            return jsonify({'error': 'Username or email already in use'}), 409
+        raise
 
     payload = dict(doctor)
     payload['username'] = user['username']
     payload['email'] = user['email']
-    payload['is_active'] = True
+    payload['is_active'] = user['is_active']
 
     return jsonify({
         'doctor': _serialize_rows([payload])[0],
@@ -468,42 +511,61 @@ def list_admin_patients():
 def create_patient():
     data = request.get_json(silent=True) or {}
     required = ['username', 'email', 'firstName', 'lastName']
-    if not all(data.get(field) for field in required):
-        return jsonify({'error': 'Missing required patient fields'}), 400
+    cleaned, field_error = _required_fields(data, required)
+    if field_error:
+        return jsonify({'error': field_error}), 400
+
+    username = cleaned['username']
+    email = cleaned['email'].lower()
+    is_active = bool(data.get('isActive', True))
+
+    # Merge cleaned required fields so insert helpers see stripped values.
+    data = {**data, **cleaned, 'email': email}
+
+    if _username_or_email_taken(username, email):
+        return jsonify({'error': 'Username or email already in use'}), 409
 
     temp_password = _generate_temp_password()
     password_hash, salt = _build_password_hash(temp_password)
 
-    with DatabaseTransaction() as cursor:
-        cursor.execute(
-            """
-            INSERT INTO users (username, email, password_hash, salt, role, must_change_password)
-            VALUES (%s, %s, %s, %s, 'patient', true)
-            RETURNING id, username, email, role
-            """,
-            (_clean_data_value(data, 'username'), _clean_data_value(data, 'email').lower(), password_hash, salt),
-        )
-        user = cursor.fetchone()
-
-        cursor.execute(
-            """
-            INSERT INTO patients (
-                user_id, first_name, last_name, date_of_birth, phone, address, city,
-                state, zip_code, emergency_contact_name, emergency_contact_phone
+    try:
+        with DatabaseTransaction() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO users (
+                    username, email, password_hash, salt, role,
+                    must_change_password, is_active
+                )
+                VALUES (%s, %s, %s, %s, 'patient', true, %s)
+                RETURNING id, username, email, role, is_active
+                """,
+                (username, email, password_hash, salt, is_active),
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-            RETURNING id, user_id, first_name, last_name, date_of_birth, phone,
-                      address, city, state, zip_code, emergency_contact_name,
-                      emergency_contact_phone, created_at, updated_at
-            """,
-            _build_patient_insert_values(data, user['id']),
-        )
-        patient = cursor.fetchone()
+            user = cursor.fetchone()
+
+            cursor.execute(
+                """
+                INSERT INTO patients (
+                    user_id, first_name, last_name, date_of_birth, phone, address, city,
+                    state, zip_code, emergency_contact_name, emergency_contact_phone
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id, user_id, first_name, last_name, date_of_birth, phone,
+                          address, city, state, zip_code, emergency_contact_name,
+                          emergency_contact_phone, created_at, updated_at
+                """,
+                _build_patient_insert_values(data, user['id']),
+            )
+            patient = cursor.fetchone()
+    except Exception as exc:
+        if _is_unique_violation(exc):
+            return jsonify({'error': 'Username or email already in use'}), 409
+        raise
 
     payload = dict(patient)
     payload['username'] = user['username']
     payload['email'] = user['email']
-    payload['is_active'] = True
+    payload['is_active'] = user['is_active']
 
     return jsonify({
         'patient': _serialize_rows([payload])[0],

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -15,7 +15,8 @@ from api.utils.security import (
     verify_password, validate_password_strength
 )
 from api.utils.session_manager import (
-    create_session, invalidate_session, invalidate_other_user_sessions
+    create_session, invalidate_session,
+    invalidate_other_user_sessions, invalidate_all_user_sessions
 )
 from api.utils.audit_log import (
     log_login, log_logout, log_password_change,
@@ -398,8 +399,12 @@ def change_password():
         execute_query(update_query, (new_password_hash, new_salt_str, request.user['id']))
         
         # Invalidate other sessions (force re-login on other devices), keep current.
-        if hasattr(request, 'session_token') and request.session_token:
-            invalidate_other_user_sessions(request.user['id'], request.session_token)
+        # If the current token is missing, fall back to wiping all sessions.
+        current_token = getattr(request, 'session_token', None)
+        if current_token:
+            invalidate_other_user_sessions(request.user['id'], current_token)
+        else:
+            invalidate_all_user_sessions(request.user['id'])
         
         log_password_change(request.user['id'], False, request)
         

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -15,7 +15,7 @@ from api.utils.security import (
     verify_password, validate_password_strength
 )
 from api.utils.session_manager import (
-    create_session, invalidate_session, invalidate_all_user_sessions
+    create_session, invalidate_session, invalidate_other_user_sessions
 )
 from api.utils.audit_log import (
     log_login, log_logout, log_password_change,
@@ -397,8 +397,9 @@ def change_password():
         """
         execute_query(update_query, (new_password_hash, new_salt_str, request.user['id']))
         
-        # Invalidate all other sessions (force re-login on other devices)
-        invalidate_all_user_sessions(request.user['id'])
+        # Invalidate other sessions (force re-login on other devices), keep current.
+        if hasattr(request, 'session_token') and request.session_token:
+            invalidate_other_user_sessions(request.user['id'], request.session_token)
         
         log_password_change(request.user['id'], False, request)
         
@@ -437,7 +438,14 @@ def get_current_user():
     Get current user information
     """
     try:
-        return jsonify({'user': request.user}), 200
+        user = dict(request.user)
+        # Serialize UUID ids for JSON clients.
+        if 'id' in user:
+            user['id'] = str(user['id'])
+        return jsonify({
+            'user': user,
+            'requirePasswordChange': bool(user.get('requirePasswordChange')),
+        }), 200
     except Exception as e:
         current_app.logger.exception("Get user error")
         return jsonify({'error': 'Failed to get user information'}), 500

--- a/api/tests/test_auth_admin_create.py
+++ b/api/tests/test_auth_admin_create.py
@@ -1,0 +1,250 @@
+"""
+Auth session lifecycle and admin user-creation tests.
+"""
+
+from unittest.mock import patch
+import uuid
+
+import pytest
+
+from api.db.connection import execute_query
+from api.tests.conftest import login_as, requires_db
+
+
+def _unique_suffix():
+    return uuid.uuid4().hex[:10]
+
+
+def _admin_auth_headers():
+    return {
+        'Authorization': 'Bearer fake-admin-token',
+        'Content-Type': 'application/json',
+    }
+
+
+def _cleanup_user(username: str):
+    row = execute_query(
+        'SELECT id FROM users WHERE username = %s',
+        (username,),
+        fetch_one=True,
+    )
+    if row:
+        execute_query('DELETE FROM users WHERE id = %s', (row['id'],))
+
+
+@requires_db
+def test_logout_invalidates_session(client):
+    headers = login_as(client, 'doctor1', 'Doctor123!')
+    token = headers['Authorization'].split(' ', 1)[1]
+
+    logout_response = client.post('/api/auth/logout', headers=headers)
+    assert logout_response.status_code == 200, logout_response.get_json()
+
+    me_response = client.get(
+        '/api/auth/me',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    assert me_response.status_code == 401
+
+
+@requires_db
+def test_logout_clears_cookie_auth(client):
+    login_response = client.post('/api/auth/login', json={
+        'username': 'doctor1',
+        'password': 'Doctor123!',
+    })
+    assert login_response.status_code == 200, login_response.get_json()
+    token = login_response.get_json()['sessionToken']
+
+    # Use cookie only (no Bearer) — mirrors post-localStorage-clear behavior.
+    client.set_cookie('sessionToken', token)
+    logout_response = client.post('/api/auth/logout')
+    assert logout_response.status_code == 200, logout_response.get_json()
+
+    me_response = client.get('/api/auth/me')
+    assert me_response.status_code == 401
+
+
+@requires_db
+def test_change_password_keeps_current_session(client):
+    suffix = _unique_suffix()
+    username = f'pwchange_{suffix}'
+    email = f'{username}@example.com'
+    original_password = 'TempPass123!'
+    new_password = 'NewPass456!'
+
+    register = client.post('/api/auth/register', json={
+        'username': username,
+        'email': email,
+        'password': original_password,
+        'firstName': 'Pw',
+        'lastName': 'Change',
+        'dateOfBirth': '1990-01-01',
+    })
+    assert register.status_code == 201, register.get_json()
+
+    try:
+        headers = login_as(client, username, original_password)
+        change = client.post('/api/auth/change-password', headers=headers, json={
+            'currentPassword': original_password,
+            'newPassword': new_password,
+        })
+        assert change.status_code == 200, change.get_json()
+
+        me = client.get('/api/auth/me', headers=headers)
+        assert me.status_code == 200, me.get_json()
+        assert me.get_json()['user']['username'] == username
+    finally:
+        _cleanup_user(username)
+
+
+@requires_db
+def test_must_change_password_blocks_phi_but_allows_auth_endpoints(client):
+    suffix = _unique_suffix()
+    username = f'mustchg_{suffix}'
+    email = f'{username}@example.com'
+    password = 'TempPass123!'
+
+    register = client.post('/api/auth/register', json={
+        'username': username,
+        'email': email,
+        'password': password,
+        'firstName': 'Must',
+        'lastName': 'Change',
+        'dateOfBirth': '1991-02-02',
+    })
+    assert register.status_code == 201, register.get_json()
+
+    try:
+        execute_query(
+            'UPDATE users SET must_change_password = true WHERE username = %s',
+            (username,),
+        )
+        headers = login_as(client, username, password)
+
+        me = client.get('/api/auth/me', headers=headers)
+        assert me.status_code == 200, me.get_json()
+        assert me.get_json()['requirePasswordChange'] is True
+
+        blocked = client.get('/api/patients/me', headers=headers)
+        assert blocked.status_code == 403
+        assert blocked.get_json().get('code') == 'PASSWORD_CHANGE_REQUIRED'
+
+        change = client.post('/api/auth/change-password', headers=headers, json={
+            'currentPassword': password,
+            'newPassword': 'ChangedPass123!',
+        })
+        assert change.status_code == 200, change.get_json()
+
+        allowed = client.get('/api/patients/me', headers=headers)
+        assert allowed.status_code == 200, allowed.get_json()
+    finally:
+        _cleanup_user(username)
+
+
+@requires_db
+@patch('api.routes.admin._verify_token_or_raise')
+def test_admin_create_doctor_duplicate_returns_409(mock_verify, client):
+    mock_verify.return_value = {
+        'preferred_username': 'admin@hudsonitconsulting.com',
+        'email': 'admin@hudsonitconsulting.com',
+        'name': 'Admin User',
+        'tid': 'test-tenant',
+    }
+    suffix = _unique_suffix()
+    username = f'admdoc_{suffix}'
+    email = f'{username}@example.com'
+    payload = {
+        'username': username,
+        'email': email,
+        'firstName': 'Ada',
+        'lastName': 'Doctor',
+        'specialty': 'Internal Medicine',
+        'licenseNumber': f'LIC-{suffix}',
+        'isActive': True,
+    }
+
+    try:
+        first = client.post(
+            '/api/admin/doctors',
+            headers=_admin_auth_headers(),
+            json=payload,
+        )
+        assert first.status_code == 201, first.get_json()
+        assert first.get_json().get('temporaryPassword')
+
+        duplicate = client.post(
+            '/api/admin/doctors',
+            headers=_admin_auth_headers(),
+            json=payload,
+        )
+        assert duplicate.status_code == 409
+        assert 'already in use' in duplicate.get_json()['error'].lower()
+    finally:
+        _cleanup_user(username)
+
+
+@requires_db
+@patch('api.routes.admin._verify_token_or_raise')
+def test_admin_create_patient_respects_is_active(mock_verify, client):
+    mock_verify.return_value = {
+        'preferred_username': 'admin@hudsonitconsulting.com',
+        'email': 'admin@hudsonitconsulting.com',
+        'name': 'Admin User',
+        'tid': 'test-tenant',
+    }
+    suffix = _unique_suffix()
+    username = f'admpat_{suffix}'
+    email = f'{username}@example.com'
+
+    try:
+        created = client.post(
+            '/api/admin/patients',
+            headers=_admin_auth_headers(),
+            json={
+                'username': username,
+                'email': email,
+                'firstName': 'Pat',
+                'lastName': 'Inactive',
+                'isActive': False,
+            },
+        )
+        assert created.status_code == 201, created.get_json()
+        body = created.get_json()
+        assert body['patient']['is_active'] is False
+        assert body.get('temporaryPassword')
+
+        login = client.post('/api/auth/login', json={
+            'username': username,
+            'password': body['temporaryPassword'],
+        })
+        assert login.status_code == 403
+        assert 'inactive' in login.get_json()['error'].lower()
+    finally:
+        _cleanup_user(username)
+
+
+@requires_db
+@patch('api.routes.admin._verify_token_or_raise')
+def test_admin_create_rejects_blank_required_fields(mock_verify, client):
+    mock_verify.return_value = {
+        'preferred_username': 'admin@hudsonitconsulting.com',
+        'email': 'admin@hudsonitconsulting.com',
+        'name': 'Admin User',
+        'tid': 'test-tenant',
+    }
+
+    response = client.post(
+        '/api/admin/doctors',
+        headers=_admin_auth_headers(),
+        json={
+            'username': '   ',
+            'email': 'blank@example.com',
+            'firstName': 'A',
+            'lastName': 'B',
+            'specialty': 'Family',
+            'licenseNumber': 'L1',
+        },
+    )
+    assert response.status_code == 400
+    assert 'username' in response.get_json()['error'].lower()

--- a/api/tests/test_auth_admin_create.py
+++ b/api/tests/test_auth_admin_create.py
@@ -99,6 +99,43 @@ def test_change_password_keeps_current_session(client):
 
 
 @requires_db
+def test_change_password_invalidates_other_sessions(client):
+    suffix = _unique_suffix()
+    username = f'pwsessions_{suffix}'
+    email = f'{username}@example.com'
+    original_password = 'TempPass123!'
+    new_password = 'NewPass456!'
+
+    register = client.post('/api/auth/register', json={
+        'username': username,
+        'email': email,
+        'password': original_password,
+        'firstName': 'Pw',
+        'lastName': 'Sessions',
+        'dateOfBirth': '1990-01-01',
+    })
+    assert register.status_code == 201, register.get_json()
+
+    try:
+        current_headers = login_as(client, username, original_password)
+        other_headers = login_as(client, username, original_password)
+
+        change = client.post('/api/auth/change-password', headers=current_headers, json={
+            'currentPassword': original_password,
+            'newPassword': new_password,
+        })
+        assert change.status_code == 200, change.get_json()
+
+        still_valid = client.get('/api/auth/me', headers=current_headers)
+        assert still_valid.status_code == 200, still_valid.get_json()
+
+        other_session = client.get('/api/auth/me', headers=other_headers)
+        assert other_session.status_code == 401
+    finally:
+        _cleanup_user(username)
+
+
+@requires_db
 def test_must_change_password_blocks_phi_but_allows_auth_endpoints(client):
     suffix = _unique_suffix()
     username = f'mustchg_{suffix}'

--- a/api/utils/session_manager.py
+++ b/api/utils/session_manager.py
@@ -113,6 +113,22 @@ def invalidate_all_user_sessions(user_id):
     
     execute_query(query, (user_id,))
 
+
+def invalidate_other_user_sessions(user_id, except_token):
+    """
+    Invalidate all sessions for a user except the current one.
+
+    Used after password change so other devices are forced to re-login
+    without kicking out the session that just completed the change.
+    """
+    query = """
+        DELETE FROM user_sessions
+        WHERE user_id = %s
+          AND session_token <> %s
+    """
+    execute_query(query, (user_id, except_token))
+
+
 def cleanup_expired_sessions():
     """Clean up expired sessions"""
     query = """

--- a/src/App.vue
+++ b/src/App.vue
@@ -327,6 +327,7 @@ const navButtons = computed<NavButton[]>(() => {
 const isPortalMessagingUser = computed(() => {
   return !!currentUser.value
     && !adminSession.value
+    && !currentUser.value.requirePasswordChange
     && (currentUser.value.role === 'doctor' || currentUser.value.role === 'patient')
 })
 
@@ -335,7 +336,10 @@ const showFeatureRequestButton = computed(() => {
 })
 
 const isProviderUser = computed(() => {
-  return !!currentUser.value && currentUser.value.role === 'doctor' && !adminSession.value
+  return !!currentUser.value
+    && currentUser.value.role === 'doctor'
+    && !adminSession.value
+    && !currentUser.value.requirePasswordChange
 })
 
 const unreadProviderAlertCount = computed(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -235,7 +235,7 @@ type ProviderAlertEventRow = {
 
 const route = useRoute()
 const router = useRouter()
-const currentUser = ref<{ name?: string; username?: string; role?: string } | null>(null)
+const currentUser = ref<{ name?: string; username?: string; role?: string; requirePasswordChange?: boolean } | null>(null)
 const showSidebar = ref(false)
 const showFeatureRequestModal = ref(false)
 const featureRequestDescription = ref('')
@@ -302,6 +302,9 @@ const pageTitle = computed(() => {
 const navButtons = computed<NavButton[]>(() => {
   if (adminSession.value) return []
   if (!currentUser.value) return []
+  if (currentUser.value.requirePasswordChange) {
+    return [{ label: 'Profile', to: '/profile' }]
+  }
   if (currentUser.value.role === 'doctor') {
     return [
       { label: 'Dashboard', to: '/provider' },
@@ -738,13 +741,13 @@ async function submitFeatureRequest() {
   }
 }
 
-const handleLogout = () => {
+const handleLogout = async () => {
   if (adminSession.value) {
     clearAdminSession()
     router.push('/admin')
     return
   }
-  logout()
+  await logout()
   currentUser.value = null
   router.push('/')
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,10 @@ interface ApiResponse<T = any> {
   data?: T;
   error?: string;
   message?: string;
+  attemptsRemaining?: number;
+  minutesRemaining?: number;
+  minutesLocked?: number;
+  code?: string;
 }
 
 /**
@@ -52,6 +56,10 @@ async function request<T>(
     if (!response.ok) {
       return {
         error: data?.error || `HTTP ${response.status}: ${response.statusText}`,
+        attemptsRemaining: data?.attemptsRemaining,
+        minutesRemaining: data?.minutesRemaining,
+        minutesLocked: data?.minutesLocked,
+        code: data?.code,
       };
     }
     

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
-import { getCurrentUser, validateSession } from '@/store'
+import { getCurrentUser, requiresPasswordChange, validateSession } from '@/store'
 
 const routes: RouteRecordRaw[] = [
   {
@@ -70,9 +70,7 @@ const router = createRouter({
 
 // Navigation guard with session validation
 router.beforeEach(async (to, _from, next) => {
-  const user = getCurrentUser()
-  
-  // Validate session token for protected routes
+  // Validate session token for protected routes first so currentUser is fresh.
   if (to.meta.requiresAuth) {
     const isValid = await validateSession()
     if (!isValid) {
@@ -80,20 +78,47 @@ router.beforeEach(async (to, _from, next) => {
       return
     }
   }
-  
+
+  const user = getCurrentUser()
+
   if (to.meta.requiresAuth && !user) {
     next('/')
-  } else if (to.meta.requiresAuth && to.meta.role && user?.role !== to.meta.role) {
+    return
+  }
+
+  if (to.meta.requiresAuth && to.meta.role && user?.role !== to.meta.role) {
     next('/')
-  } else if (to.path === '/' && user) {
-    // Redirect logged in users to their dashboard
+    return
+  }
+
+  // Force password change before any other authenticated destination.
+  if (
+    user &&
+    requiresPasswordChange(user) &&
+    to.path !== '/profile' &&
+    to.path !== '/admin' &&
+    to.path !== '/'
+  ) {
+    next({ path: '/profile', query: { password: 'required' } })
+    return
+  }
+
+  if (to.path === '/' && user) {
+    if (requiresPasswordChange(user)) {
+      next({ path: '/profile', query: { password: 'required' } })
+      return
+    }
     next(user.role === 'doctor' ? '/provider' : '/patient')
-  } else if (to.path === '/admin') {
+    return
+  }
+
+  if (to.path === '/admin') {
     // /admin handles its own auth via Microsoft SSO — always allow
     next()
-  } else {
-    next()
+    return
   }
+
+  next()
 })
 
 export default router

--- a/src/store.ts
+++ b/src/store.ts
@@ -38,12 +38,11 @@ export function clearAdminSession(): void {
   adminSession.value = null
 }
 
-// Hardcoded users for demo
+// Hardcoded users for demo (legacy offline helpers only — not used for login)
 export const users: User[] = [
   {
     id: 1,
     username: 'doctor1',
-    password: 'doctor123',
     email: 'doctor1@hhs.local',
     role: 'doctor',
     name: 'Dr. Sarah Johnson'
@@ -51,7 +50,6 @@ export const users: User[] = [
   {
     id: 2,
     username: 'patient1',
-    password: 'patient123',
     email: 'patient1@hhs.local',
     role: 'patient',
     name: 'John Smith',
@@ -131,7 +129,7 @@ export let currentUser: User | null = null
 export async function validateSession(): Promise<boolean> {
   const token = localStorage.getItem('sessionToken')
   if (!token) {
-    logout()
+    await logout()
     return false
   }
 
@@ -144,14 +142,38 @@ export async function validateSession(): Promise<boolean> {
 
     if (!response.ok) {
       // Session expired or invalid - auto logout
-      logout()
+      await logout()
       return false
+    }
+
+    const data = await response.json()
+    if (data?.user) {
+      const requirePasswordChange = Boolean(
+        data.requirePasswordChange ?? data.user.requirePasswordChange
+      )
+      const nextUser: User = {
+        id: data.user.id,
+        username: data.user.username,
+        password: '',
+        role: data.user.role,
+        name: data.user.username,
+        email: data.user.email,
+        requirePasswordChange,
+      }
+      setCurrentUser(nextUser)
+      localStorage.setItem('currentUser', JSON.stringify({
+        id: nextUser.id,
+        username: nextUser.username,
+        email: nextUser.email,
+        role: nextUser.role,
+        requirePasswordChange,
+      }))
     }
 
     return true
   } catch (error) {
     console.error('Session validation error:', error)
-    logout()
+    await logout()
     return false
   }
 }
@@ -161,14 +183,15 @@ const storedUser = localStorage.getItem('currentUser')
 if (storedUser) {
   try {
     const userData = JSON.parse(storedUser)
-    // Convert API user format to local User format
+    // Preserve UUID string ids from the API (do not parseInt).
     currentUser = {
-      id: parseInt(userData.id) || 0,
+      id: userData.id,
       username: userData.username,
       password: '', // Not stored in localStorage
       role: userData.role,
       name: userData.username, // Use username as name for now
-      email: userData.email
+      email: userData.email,
+      requirePasswordChange: Boolean(userData.requirePasswordChange),
     }
   } catch (e) {
     console.error('Failed to parse stored user:', e)
@@ -183,16 +206,25 @@ export function getCurrentUser(): User | null {
   return currentUser
 }
 
-export function authenticateUser(username: string, password: string): User | null {
-  const user = users.find(u => u.username === username && u.password === password)
-  if (user) {
-    setCurrentUser(user)
-    return user
-  }
-  return null
+export function requiresPasswordChange(user: User | null = currentUser): boolean {
+  return Boolean(user?.requirePasswordChange)
 }
 
-export function logout() {
+export async function logout() {
+  const token = localStorage.getItem('sessionToken')
+  if (token) {
+    try {
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+    } catch {
+      // Best-effort server logout; always clear local state below.
+    }
+  }
   setCurrentUser(null)
   localStorage.removeItem('sessionToken')
   localStorage.removeItem('currentUser')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   role: 'doctor' | 'patient'
   name?: string
   birthday?: string
+  requirePasswordChange?: boolean
 }
 
 export interface Appointment {

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -101,14 +101,26 @@
             </div>
           </form>
 
-          <div v-if="newProviderPassword" class="temp-password">
-            Temporary provider password: <strong>{{ newProviderPassword }}</strong>
+          <div v-if="newProviderCredentials" class="temp-password">
+            <div class="temp-password-text">
+              Provider created. Username: <strong>{{ newProviderCredentials.username }}</strong>
+              — temporary password: <strong>{{ newProviderCredentials.password }}</strong>
+            </div>
+            <div class="temp-password-actions">
+              <button type="button" class="section-btn secondary" @click="copyText(newProviderCredentials.password)">
+                Copy password
+              </button>
+              <button type="button" class="section-btn secondary" @click="newProviderCredentials = null">
+                Dismiss
+              </button>
+            </div>
           </div>
 
           <div class="table-wrap">
             <table class="entity-table">
               <thead>
                 <tr>
+                  <th>Username</th>
                   <th>Name</th>
                   <th>Email</th>
                   <th>Specialty</th>
@@ -119,6 +131,7 @@
               </thead>
               <tbody>
                 <tr v-for="provider in providers" :key="provider.id">
+                  <td>{{ provider.username || '—' }}</td>
                   <td>{{ provider.first_name }} {{ provider.last_name }}</td>
                   <td>{{ provider.email }}</td>
                   <td>{{ provider.specialty }}</td>
@@ -169,14 +182,26 @@
             </div>
           </form>
 
-          <div v-if="newPatientPassword" class="temp-password">
-            Temporary patient password: <strong>{{ newPatientPassword }}</strong>
+          <div v-if="newPatientCredentials" class="temp-password">
+            <div class="temp-password-text">
+              Patient created. Username: <strong>{{ newPatientCredentials.username }}</strong>
+              — temporary password: <strong>{{ newPatientCredentials.password }}</strong>
+            </div>
+            <div class="temp-password-actions">
+              <button type="button" class="section-btn secondary" @click="copyText(newPatientCredentials.password)">
+                Copy password
+              </button>
+              <button type="button" class="section-btn secondary" @click="newPatientCredentials = null">
+                Dismiss
+              </button>
+            </div>
           </div>
 
           <div class="table-wrap">
             <table class="entity-table">
               <thead>
                 <tr>
+                  <th>Username</th>
                   <th>Name</th>
                   <th>Email</th>
                   <th>DOB</th>
@@ -187,6 +212,7 @@
               </thead>
               <tbody>
                 <tr v-for="patient in patients" :key="patient.id">
+                  <td>{{ patient.username || '—' }}</td>
                   <td>{{ patient.first_name }} {{ patient.last_name }}</td>
                   <td>{{ patient.email }}</td>
                   <td>{{ formatDate(patient.date_of_birth) }}</td>
@@ -327,8 +353,8 @@ const editingProviderId = ref<string>('')
 const editingPatientId = ref<string>('')
 const actionError = ref('')
 const actionMessage = ref('')
-const newProviderPassword = ref('')
-const newPatientPassword = ref('')
+const newProviderCredentials = ref<{ username: string; password: string } | null>(null)
+const newPatientCredentials = ref<{ username: string; password: string } | null>(null)
 
 const providerForm = ref<ProviderForm>(createProviderForm())
 const patientForm = ref<PatientForm>(createPatientForm())
@@ -424,6 +450,15 @@ function clearActionBanners() {
   actionMessage.value = ''
 }
 
+async function copyText(value: string) {
+  try {
+    await navigator.clipboard.writeText(value)
+    actionMessage.value = 'Temporary password copied to clipboard.'
+  } catch {
+    actionError.value = 'Could not copy password. Please copy it manually.'
+  }
+}
+
 function resetProviderForm() {
   editingProviderId.value = ''
   providerForm.value = createProviderForm()
@@ -471,7 +506,7 @@ function editPatient(patient: PatientRecord) {
 
 async function submitProvider() {
   clearActionBanners()
-  newProviderPassword.value = ''
+  newProviderCredentials.value = null
 
   try {
     if (editingProviderId.value) {
@@ -486,7 +521,10 @@ async function submitProvider() {
         body: JSON.stringify(providerForm.value)
       })
       actionMessage.value = 'Provider created successfully.'
-      newProviderPassword.value = created.temporaryPassword ?? ''
+      newProviderCredentials.value = {
+        username: created.doctor?.username || providerForm.value.username,
+        password: created.temporaryPassword ?? '',
+      }
     }
 
     resetProviderForm()
@@ -498,7 +536,7 @@ async function submitProvider() {
 
 async function submitPatient() {
   clearActionBanners()
-  newPatientPassword.value = ''
+  newPatientCredentials.value = null
 
   try {
     if (editingPatientId.value) {
@@ -513,7 +551,10 @@ async function submitPatient() {
         body: JSON.stringify(patientForm.value)
       })
       actionMessage.value = 'Patient created successfully.'
-      newPatientPassword.value = created.temporaryPassword ?? ''
+      newPatientCredentials.value = {
+        username: created.patient?.username || patientForm.value.username,
+        password: created.temporaryPassword ?? '',
+      }
     }
 
     resetPatientForm()
@@ -983,6 +1024,15 @@ async function signIn() {
   padding: 10px 12px;
   margin-bottom: 12px;
   font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.temp-password-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .table-wrap {

--- a/src/views/CheckInView.spec.ts
+++ b/src/views/CheckInView.spec.ts
@@ -1,0 +1,63 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import CheckInView from '@/views/CheckInView.vue'
+
+const { routerPush, setCurrentUser, login } = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  setCurrentUser: vi.fn(),
+  login: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush }),
+}))
+
+vi.mock('@/store', () => ({
+  getCurrentUser: () => null,
+  setCurrentUser,
+}))
+
+vi.mock('@/api', () => ({
+  authApi: {
+    login: (...args: unknown[]) => login(...args),
+  },
+}))
+
+describe('CheckInView.vue', () => {
+  beforeEach(() => {
+    routerPush.mockReset()
+    setCurrentUser.mockReset()
+    login.mockReset()
+    localStorage.clear()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('redirects to profile when credential login requires a password change', async () => {
+    login.mockResolvedValue({
+      data: {
+        sessionToken: 'token-1',
+        requirePasswordChange: true,
+        user: {
+          id: 'user-1',
+          username: 'newpatient',
+          email: 'newpatient@example.com',
+          role: 'patient',
+        },
+      },
+    })
+
+    const wrapper = mount(CheckInView)
+    await wrapper.get('button.kiosk-btn.primary').trigger('click')
+    await wrapper.get('#username').setValue('newpatient')
+    await wrapper.get('#password').setValue('TempPass123!')
+    await wrapper.get('form.kiosk-form').trigger('submit')
+    await flushPromises()
+
+    expect(login).toHaveBeenCalledWith('newpatient', 'TempPass123!')
+    expect(routerPush).toHaveBeenCalledWith({
+      path: '/profile',
+      query: { password: 'required' },
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/views/CheckInView.vue
+++ b/src/views/CheckInView.vue
@@ -307,6 +307,11 @@ const handleCredentialCheckIn = async () => {
       requirePasswordChange,
     })
 
+    if (requirePasswordChange) {
+      await router.push({ path: '/profile', query: { password: 'required' } })
+      return
+    }
+
     isLoggedInPatient.value = loginResponse.data.user.role === 'patient'
     await fetchNextAppointment()
     if (nextAppointment.value) {

--- a/src/views/CheckInView.vue
+++ b/src/views/CheckInView.vue
@@ -291,9 +291,21 @@ const handleCredentialCheckIn = async () => {
       return
     }
 
+    const requirePasswordChange = Boolean(loginResponse.data.requirePasswordChange)
+    const userPayload = {
+      ...loginResponse.data.user,
+      requirePasswordChange,
+    }
     localStorage.setItem('sessionToken', loginResponse.data.sessionToken)
-    localStorage.setItem('currentUser', JSON.stringify(loginResponse.data.user))
-    setCurrentUser(loginResponse.data.user as any)
+    localStorage.setItem('currentUser', JSON.stringify(userPayload))
+    setCurrentUser({
+      id: loginResponse.data.user.id,
+      username: loginResponse.data.user.username,
+      email: loginResponse.data.user.email,
+      role: loginResponse.data.user.role as 'doctor' | 'patient',
+      name: loginResponse.data.user.username,
+      requirePasswordChange,
+    })
 
     isLoggedInPatient.value = loginResponse.data.user.role === 'patient'
     await fetchNextAppointment()

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -41,6 +41,25 @@ const password = ref('')
 const error = ref('')
 const loading = ref(false)
 
+function formatLoginError(response: {
+  error?: string
+  attemptsRemaining?: number
+  minutesRemaining?: number
+  minutesLocked?: number
+}): string {
+  const base = response.error || 'Unable to sign in. Please try again.'
+  if (typeof response.attemptsRemaining === 'number') {
+    return `${base} (${response.attemptsRemaining} attempt${response.attemptsRemaining === 1 ? '' : 's'} remaining)`
+  }
+  if (typeof response.minutesRemaining === 'number') {
+    return `${base}. Try again in about ${response.minutesRemaining} minute${response.minutesRemaining === 1 ? '' : 's'}.`
+  }
+  if (typeof response.minutesLocked === 'number') {
+    return `${base}. Locked for ${response.minutesLocked} minute${response.minutesLocked === 1 ? '' : 's'}.`
+  }
+  return base
+}
+
 const handleLogin = async () => {
   error.value = ''
   loading.value = true
@@ -48,10 +67,8 @@ const handleLogin = async () => {
   try {
     const response = await authApi.login(username.value, password.value)
     
-    console.log('Login response:', response)
-    
     if (response.error) {
-      error.value = response.error
+      error.value = formatLoginError(response)
       return
     }
     
@@ -59,31 +76,35 @@ const handleLogin = async () => {
       // Enforce single session: clear any active admin SSO session
       clearAdminSession()
 
-      // Store session token and user data
-      localStorage.setItem('sessionToken', response.data.sessionToken)
-      localStorage.setItem('currentUser', JSON.stringify(response.data.user))
-      
-      // Update store with current user
-      setCurrentUser({
+      const requirePasswordChange = Boolean(response.data.requirePasswordChange)
+      const userPayload = {
         id: response.data.user.id,
         username: response.data.user.username,
         email: response.data.user.email,
-        role: response.data.user.role as 'doctor' | 'patient'
+        role: response.data.user.role as 'doctor' | 'patient',
+        requirePasswordChange,
+      }
+
+      // Store session token and user data
+      localStorage.setItem('sessionToken', response.data.sessionToken)
+      localStorage.setItem('currentUser', JSON.stringify(userPayload))
+      
+      // Update store with current user
+      setCurrentUser({
+        ...userPayload,
+        password: '',
+        name: response.data.user.username,
       })
       
-      console.log('Login successful, user role:', response.data.user.role)
-      
-      if (response.data.requirePasswordChange) {
+      if (requirePasswordChange) {
         router.push({ path: '/profile', query: { password: 'required' } })
         return
       }
       
       // Redirect based on user role
       if (response.data.user.role === 'doctor') {
-        console.log('Redirecting to provider dashboard')
         router.push('/provider')
       } else {
-        console.log('Redirecting to patient dashboard')
         router.push('/patient')
       }
     }

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -151,6 +151,7 @@ function clearProfilePhotoUrl() {
 async function loadPatientProfilePhoto() {
   clearProfilePhotoUrl()
   if (currentUser.value?.role !== 'patient') return
+  if (currentUser.value?.requirePasswordChange || route.query.password === 'required') return
 
   const token = localStorage.getItem('sessionToken')
   if (!token) return

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -41,7 +41,13 @@
             <p class="eyebrow">Security</p>
             <h3>Change Password</h3>
           </div>
-          <RouterLink :to="homeRoute" class="back-link">Back to Home</RouterLink>
+          <RouterLink
+            v-if="!isForcedPasswordChange"
+            :to="homeRoute"
+            class="back-link"
+          >
+            Back to Home
+          </RouterLink>
         </div>
 
         <div v-if="isForcedPasswordChange" class="info-banner">
@@ -70,7 +76,9 @@
               minlength="8"
               required
             />
-            <p class="field-help">Use at least 8 characters.</p>
+            <p class="field-help">
+              Use at least 8 characters with upper/lowercase letters, a number, and a special character.
+            </p>
           </div>
 
           <div class="form-group">
@@ -103,12 +111,14 @@
 import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { authApi } from '@/api'
+import { getCurrentUser, setCurrentUser } from '@/store'
 
 type StoredUser = {
   id?: string | number
   username?: string
   email?: string
   role?: 'doctor' | 'patient' | string
+  requirePasswordChange?: boolean
 }
 
 const route = useRoute()
@@ -192,7 +202,9 @@ const formattedRole = computed(() => {
   return role.charAt(0).toUpperCase() + role.slice(1)
 })
 const homeRoute = computed(() => currentUser.value?.role === 'doctor' ? '/provider' : '/patient')
-const isForcedPasswordChange = computed(() => route.query.password === 'required')
+const isForcedPasswordChange = computed(() => {
+  return route.query.password === 'required' || Boolean(currentUser.value?.requirePasswordChange)
+})
 
 const form = reactive({
   currentPassword: '',
@@ -254,7 +266,24 @@ async function handlePasswordChange() {
     form.newPassword = ''
     form.confirmPassword = ''
 
-    if (isForcedPasswordChange.value) {
+    // Clear forced-change flag so navigation / middleware allow dashboard access.
+    const stored = localStorage.getItem('currentUser')
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as StoredUser
+        const updated = { ...parsed, requirePasswordChange: false }
+        localStorage.setItem('currentUser', JSON.stringify(updated))
+        currentUser.value = updated
+        const storeUser = getCurrentUser()
+        if (storeUser) {
+          setCurrentUser({ ...storeUser, requirePasswordChange: false })
+        }
+      } catch {
+        // ignore parse errors; redirect still proceeds after validateSession
+      }
+    }
+
+    if (isForcedPasswordChange.value || route.query.password === 'required') {
       globalThis.setTimeout(() => {
         router.push(homeRoute.value)
       }, 1200)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the wonky login and admin user-creation flows:

### Login / session
- Logout now calls `POST /api/auth/logout` so the DB session and HttpOnly cookie are invalidated (not just localStorage).
- Password change keeps the current session and only invalidates other devices.
- `must_change_password` / password expiry is enforced in auth middleware (PHI blocked with `PASSWORD_CHANGE_REQUIRED`) and the Vue router/Profile UI.
- Login shows lockout / attempts-remaining details; UUID user ids are no longer corrupted via `parseInt` on reload.

### Admin user creation
- Duplicate username/email returns **409** instead of a 500.
- Create honors the **Active** checkbox.
- Blank/whitespace required fields are rejected.
- Admin tables show **username**; temp password banner includes username, copy, and dismiss.

### Tests
Added `api/tests/test_auth_admin_create.py` covering logout, password-change session retention, forced-change gate, admin duplicates, `isActive`, and blank-field validation. Full backend suite: 42 passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-401a9fbb-8ba2-4c2e-8120-3192f50631e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-401a9fbb-8ba2-4c2e-8120-3192f50631e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

